### PR TITLE
chore: bump litmussdk to 2.5.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ test = [
 
 
 [tool.uv.sources]
-litmussdk = { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.5.5/litmussdk-2.5.5-py3-none-any.whl" }
+litmussdk = { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.5.6/litmussdk-2.5.6-py3-none-any.whl" }
 
 [tool.ruff]
 exclude = [

--- a/uv.lock
+++ b/uv.lock
@@ -71,6 +71,15 @@ wheels = [
 ]
 
 [[package]]
+name = "argcomplete"
+version = "3.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -664,7 +673,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "influxdb", specifier = ">=5.3.2" },
     { name = "jinja2", specifier = ">=3.1.6" },
-    { name = "litmussdk", url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.5.5/litmussdk-2.5.5-py3-none-any.whl" },
+    { name = "litmussdk", url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.5.6/litmussdk-2.5.6-py3-none-any.whl" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.17.0" },
     { name = "nats-py", specifier = ">=2.11.0" },
     { name = "numpy", specifier = ">=2.3.4" },
@@ -692,10 +701,11 @@ test = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "litmussdk"
-version = "2.5.5"
-source = { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.5.5/litmussdk-2.5.5-py3-none-any.whl" }
+version = "2.5.6"
+source = { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.5.6/litmussdk-2.5.6-py3-none-any.whl" }
 dependencies = [
     { name = "appdirs" },
+    { name = "argcomplete" },
     { name = "brotli" },
     { name = "jinja2" },
     { name = "jsonschema" },
@@ -707,12 +717,13 @@ dependencies = [
     { name = "urllib3" },
 ]
 wheels = [
-    { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.5.5/litmussdk-2.5.5-py3-none-any.whl", hash = "sha256:17c9e023760adbeb896f29647d62ae2debab9b4f88af308ddac5b49f8c206be0" },
+    { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.5.6/litmussdk-2.5.6-py3-none-any.whl", hash = "sha256:aab6bd05518b9f359c0204398a39ff16c80e19cae0da00431e8a2fa8634b7ff0" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "appdirs" },
+    { name = "argcomplete" },
     { name = "brotli" },
     { name = "jinja2" },
     { name = "jsonschema" },


### PR DESCRIPTION
Automated bump triggered by the [2.5.6 SDK release](https://github.com/litmusautomation/litmus-sdk-releases/releases/tag/2.5.6).

Tests passed on the new version before this PR was opened.