### PR TITLE
chore: bump litmussdk to 2.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ test = [
 
 
 [tool.uv.sources]
-litmussdk = { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.5.6/litmussdk-2.5.6-py3-none-any.whl" }
+litmussdk = { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.6.0/litmussdk-2.6.0-py3-none-any.whl" }
 
 [tool.ruff]
 exclude = [

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "influxdb", specifier = ">=5.3.2" },
     { name = "jinja2", specifier = ">=3.1.6" },
-    { name = "litmussdk", url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.5.6/litmussdk-2.5.6-py3-none-any.whl" },
+    { name = "litmussdk", url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.6.0/litmussdk-2.6.0-py3-none-any.whl" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.17.0" },
     { name = "nats-py", specifier = ">=2.11.0" },
     { name = "numpy", specifier = ">=2.3.4" },
@@ -701,8 +701,8 @@ test = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "litmussdk"
-version = "2.5.6"
-source = { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.5.6/litmussdk-2.5.6-py3-none-any.whl" }
+version = "2.6.0"
+source = { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.6.0/litmussdk-2.6.0-py3-none-any.whl" }
 dependencies = [
     { name = "appdirs" },
     { name = "argcomplete" },
@@ -717,7 +717,7 @@ dependencies = [
     { name = "urllib3" },
 ]
 wheels = [
-    { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.5.6/litmussdk-2.5.6-py3-none-any.whl", hash = "sha256:aab6bd05518b9f359c0204398a39ff16c80e19cae0da00431e8a2fa8634b7ff0" },
+    { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.6.0/litmussdk-2.6.0-py3-none-any.whl", hash = "sha256:081c9434a4f6bcc79da453c6f34ab12b4bba3dbfd678a2a5497c088b320aaa43" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
Automated bump triggered by the [2.6.0 SDK release](https://github.com/litmusautomation/litmus-sdk-releases/releases/tag/2.6.0).

Tests passed on the new version before this PR was opened.