### PR TITLE
ci/cd: no-cache docker build, helm chart in repo, CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,61 @@
+name: CD — Deploy to Environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag to deploy (git short SHA from CI run)'
+        required: true
+        type: string
+      environment:
+        description: 'Target environment'
+        required: true
+        type: choice
+        options:
+          - dev
+          - qa
+          - staging
+          - demo
+          - cs
+          - sales
+          - prod
+
+env:
+  ORG: ghcr.io/litmusautomation
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Resolve namespace
+        id: vars
+        run: |
+          case "${{ inputs.environment }}" in
+            dev)     echo "namespace=dev-datahub-env" ;;
+            qa)      echo "namespace=qa-datahub-env" ;;
+            staging) echo "namespace=staging-datahub-env" ;;
+            prod)    echo "namespace=litmus-datacatalog" ;;
+            cs)      echo "namespace=cs-datahub-env" ;;
+            demo)    echo "namespace=demo-datahub-env" ;;
+            sales)   echo "namespace=sales-datahub-env" ;;
+            *)       echo "Unknown environment: ${{ inputs.environment }}"; exit 1 ;;
+          esac >> $GITHUB_OUTPUT
+
+      - name: Helm deploy
+        run: |
+          TAG=${{ inputs.image_tag }}
+          ENV=${{ inputs.environment }}
+          NS=${{ steps.vars.outputs.namespace }}
+
+          helm upgrade --install mcp-server-datahub helm/chart \
+            --namespace $NS \
+            -f helm/values/${ENV}.yaml \
+            --set image.repository=$ORG/litmus-mcp-server \
+            --set image.tag="$TAG" \
+            --wait --timeout 5m
+
+          echo "Deployed litmus-mcp-server:$TAG → $ENV ($NS)"
+          kubectl get pods -n $NS -l app.kubernetes.io/name=mcp-server-datahub

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,78 +1,39 @@
-#
-name: Create and publish a Docker image for Litmus MCP Server
+name: CI — Build & Push
 
 on:
   push:
-    branches: ['main']
-    tags:
-      - "v*.*.*"
-  pull_request:
-    branches: ['main']
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  PLATFORMS: "linux/amd64"
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
-  docker-build:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    name: Build Docker image (ghcr.io/litmusautomation/litmus-mcp-server)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
-
+  build-push:
+    runs-on: [self-hosted, github-runner-0]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Log in to the Container registry
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set image tag
+        id: tag
+        run: echo "tag=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
-        env:
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-        with:
-          platforms: ${{ env.PLATFORMS }}
+      - name: Build & push
+        run: |
+          docker build --no-cache \
+            -t ghcr.io/litmusautomation/litmus-mcp-server:${{ steps.tag.outputs.tag }} \
+            -t ghcr.io/litmusautomation/litmus-mcp-server:latest \
+            .
+          docker push ghcr.io/litmusautomation/litmus-mcp-server:${{ steps.tag.outputs.tag }}
+          docker push ghcr.io/litmusautomation/litmus-mcp-server:latest
 
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
-        with:
-          platforms: ${{ env.PLATFORMS }}
-          push: ${{ github.event_name != 'pull_request' }}
-          sbom: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          annotations: ${{ steps.meta.outputs.annotations }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Prune old images
+        run: docker image prune -f
 
-      - name: Generate artifact attestation
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
+      - name: Summary
+        run: echo "### Built \`litmus-mcp-server:${{ steps.tag.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY

--- a/helm/chart/Chart.yaml
+++ b/helm/chart/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: mcp-server-datahub
+description: Model Context Protocol Server for DataHub catalog API, callable via AI tools (Claude Code)
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - datahub
+  - mcp
+  - catalog
+  - ai
+maintainers:
+  - name: Litmus Automation

--- a/helm/chart/templates/_helpers.tpl
+++ b/helm/chart/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mcp-server-datahub.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "mcp-server-datahub.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mcp-server-datahub.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "mcp-server-datahub.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mcp-server-datahub.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-server-datahub.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/chart/templates/deployment.yaml
+++ b/helm/chart/templates/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-server-datahub.fullname" . }}
+  labels:
+    {{- include "mcp-server-datahub.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "mcp-server-datahub.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "mcp-server-datahub.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8001
+              protocol: TCP
+          env:
+            - name: DATAHUB_GMS_URL
+              value: {{ .Values.datahub.gmsUrl | quote }}
+            - name: DATAHUB_GMS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.datahub.gmsTokenSecret }}
+                  key: token
+            - name: MCP_SERVER_URL
+              value: {{ .Values.mcpServerUrl | quote }}
+            {{- with .Values.extraEnvs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 5
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/chart/templates/ingress.yaml
+++ b/helm/chart/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "mcp-server-datahub.fullname" . }}
+  labels:
+    {{- include "mcp-server-datahub.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "mcp-server-datahub.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/chart/templates/secret.yaml
+++ b/helm/chart/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- /*
+This template is intentionally a no-op placeholder.
+The DATAHUB_GMS_TOKEN secret must be created out-of-band by the operator:
+
+  kubectl create secret generic datahub-gms-token \
+    --from-literal=token=<YOUR_PERSONAL_ACCESS_TOKEN> \
+    -n <namespace>
+
+The Deployment references it via .Values.datahub.gmsTokenSecret (default: "datahub-gms-token").
+Do NOT store the token value in values.yaml or any committed file.
+*/ -}}

--- a/helm/chart/templates/service.yaml
+++ b/helm/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcp-server-datahub.fullname" . }}
+  labels:
+    {{- include "mcp-server-datahub.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "mcp-server-datahub.selectorLabels" . | nindent 4 }}

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -1,0 +1,74 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/atoolg-le/catalog-mcp-server
+  pullPolicy: IfNotPresent
+  # Override with the exact image tag on deploy, e.g. the git short SHA
+  tag: "9c312d41"
+
+imagePullSecrets:
+  - name: ghcr-secret
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: false
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 8001
+
+# Ingress: optionally expose MCP server externally (usually only needed for AI tools outside cluster)
+ingress:
+  enabled: false
+  className: "nginx"
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  hosts:
+    - host: mcp-catalog.example.litmus.dev
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: mcp-catalog-tls
+      hosts:
+        - mcp-catalog.example.litmus.dev
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+autoscaling:
+  enabled: false
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# DataHub GMS connection
+datahub:
+  gmsUrl: "http://datahub-datahub-gms:8080"
+  # Name of the K8s Secret that holds the GMS personal access token.
+  # The secret must have a key named "token".
+  # Create with: kubectl create secret generic datahub-gms-token --from-literal=token=<TOKEN> -n <namespace>
+  gmsTokenSecret: "datahub-gms-token"
+
+# MCP server URL (used by clients / AI tools to reach this service)
+mcpServerUrl: "http://mcp-server-datahub:8001/mcp"
+
+# Extra environment variables
+extraEnvs: []

--- a/helm/values/cs.yaml
+++ b/helm/values/cs.yaml
@@ -1,0 +1,12 @@
+image:
+  repository: ghcr.io/litmusautomation/catalog-mcp-server
+  tag: "9c312d4"
+
+datahub:
+  gmsUrl: "http://datahub-datahub-gms:8080"
+  gmsTokenSecret: "datahub-gms-token"
+
+mcpServerUrl: "http://mcp-server-datahub:8001/mcp"
+
+ingress:
+  enabled: false

--- a/helm/values/demo.yaml
+++ b/helm/values/demo.yaml
@@ -1,0 +1,12 @@
+image:
+  repository: ghcr.io/litmusautomation/catalog-mcp-server
+  tag: "9c312d4"
+
+datahub:
+  gmsUrl: "http://datahub-datahub-gms:8080"
+  gmsTokenSecret: "datahub-gms-token"
+
+mcpServerUrl: "http://mcp-server-datahub:8001/mcp"
+
+ingress:
+  enabled: false

--- a/helm/values/dev.yaml
+++ b/helm/values/dev.yaml
@@ -1,0 +1,11 @@
+image:
+  tag: "3c84301"
+
+datahub:
+  gmsUrl: "http://datahub-datahub-gms:8080"
+  gmsTokenSecret: "datahub-gms-token"
+
+mcpServerUrl: "http://mcp-server-datahub:8001/mcp"
+
+ingress:
+  enabled: false   # internal-only for dev; enable if external AI tools need access

--- a/helm/values/prod.yaml
+++ b/helm/values/prod.yaml
@@ -1,0 +1,19 @@
+image:
+  tag: "9c312d41"
+
+datahub:
+  gmsUrl: "http://datahub-datahub-gms:8080"
+  gmsTokenSecret: "datahub-gms-token"
+
+mcpServerUrl: "http://mcp-server-datahub:8001/mcp"
+
+resources:
+  requests:
+    cpu: "1m"
+    memory: 128Mi
+  limits:
+    cpu: "500m"
+    memory: 256Mi
+
+ingress:
+  enabled: false

--- a/helm/values/qa.yaml
+++ b/helm/values/qa.yaml
@@ -1,0 +1,12 @@
+image:
+  repository: ghcr.io/litmusautomation/catalog-mcp-server
+  tag: "9c312d4"
+
+datahub:
+  gmsUrl: "http://datahub-datahub-gms:8080"
+  gmsTokenSecret: "datahub-gms-token"
+
+mcpServerUrl: "http://mcp-server-datahub:8001/mcp"
+
+ingress:
+  enabled: false   # internal-only for qa; enable if external AI tools need access

--- a/helm/values/sales.yaml
+++ b/helm/values/sales.yaml
@@ -1,0 +1,12 @@
+image:
+  repository: ghcr.io/litmusautomation/catalog-mcp-server
+  tag: "9c312d4"
+
+datahub:
+  gmsUrl: "http://datahub-datahub-gms:8080"
+  gmsTokenSecret: "datahub-gms-token"
+
+mcpServerUrl: "http://mcp-server-datahub:8001/mcp"
+
+ingress:
+  enabled: false

--- a/helm/values/staging.yaml
+++ b/helm/values/staging.yaml
@@ -1,0 +1,33 @@
+image:
+  repository: ghcr.io/litmusautomation/catalog-mcp-server
+  tag: "9c312d4"
+
+datahub:
+  gmsUrl: "http://datahub-datahub-gms:8080"
+  gmsTokenSecret: "datahub-gms-token"
+
+mcpServerUrl: "http://mcp-server-datahub:8001/mcp"
+
+resources:
+  requests:
+    cpu: "1m"
+    memory: 128Mi
+  limits:
+    cpu: "500m"
+    memory: 256Mi
+
+ingress:
+  enabled: true
+  className: "nginxvpn"
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: "letsencrypt-dev"
+  hosts:
+    - host: mcp-catalog-staging.litmus.dev
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: mcp-catalog-staging-tls
+      hosts:
+        - mcp-catalog-staging.litmus.dev


### PR DESCRIPTION
## Summary
- Rewrote `docker.yaml` CI: `--no-cache` build, self-hosted runner (`github-runner-0`), git short SHA tag
- Added `helm/chart/` — mcp-server-datahub Helm chart (moved from datacatalog-terraform)
- Added `helm/values/<env>.yaml` — per-env values for dev, qa, staging, cs, demo, sales, prod
- Added `cd.yml` — `workflow_dispatch` CD: checkout repo, run `helm upgrade --install` directly on `[self-hosted, linux, x64]` runner, supports all 7 envs