### PR TITLE
Add Streamable HTTP transport and local litmus-sdk-cli bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,20 @@ The official [Litmus Automation](https://litmus.io) **Model Context Protocol (MC
 
 ## Quick Launch
 
-### Start an HTTP SSE MCP Server using Docker
+### Start an HTTP MCP Server using Docker
 
-Run the server in Docker (HTTP SSE only)
+Run the server in Docker (HTTP only)
 
 ```bash
 docker run -d --name litmus-mcp-server -p 8000:8000 ghcr.io/litmusautomation/litmus-mcp-server:latest
 ```
+
+The HTTP server exposes both MCP transports on port 8000:
+
+- `http://<host>:8000/mcp` - Streamable HTTP (current MCP spec, recommended)
+- `http://<host>:8000/sse` - HTTP+SSE (legacy transport, kept for older clients)
+
+Clients that support Streamable HTTP should point at `/mcp` (e.g. `"type": "http"`, as in the Claude Code example below). The remaining client examples use the SSE endpoint; swap in `/mcp` if your client supports it, keeping the same headers.
 
 NOTE: The Litmus MCP Server is built for linux/AMD64 platforms. If running in Docker on ARM64, specify the AMD64 platform type by including the --platform argument:
 
@@ -133,8 +140,8 @@ Run Claude from a directory that includes a configuration file at `~/.claude/mcp
 {
   "mcpServers": {
     "litmus-mcp-server": {
-      "type": "sse",
-      "url": "http://localhost:8000/sse",
+      "type": "http",
+      "url": "http://localhost:8000/mcp",
       "headers": {
         "EDGE_URL": "${EDGE_URL}",
         "EDGE_API_CLIENT_ID": "${EDGE_API_CLIENT_ID}",
@@ -435,7 +442,7 @@ LEM tools talk to a Litmus Edge Manager (cloud) tenant rather than a single edge
 - `EDGE_MANAGER_ADMIN_URL` (optional): admin URL, defaults to the EDGE_MANAGER_URL host on port `8446`
 
 **\*\*\*\* SDK Fallback Tools Requirements:**
-`litmus_sdk_discover` and `litmus_sdk_call` are backed by the standalone `litmus-sdk-cli` Go binary (installed in the Docker image; for local runs install it from the `cli-v*` releases at https://github.com/litmusautomation/litmus-sdk-releases/releases and put it on PATH, or set `LITMUS_SDK_CLI_PATH`). They expose the full generated SDK surface beyond the curated tools above. Notes:
+`litmus_sdk_discover` and `litmus_sdk_call` are backed by the standalone `litmus-sdk-cli` Go binary. The Docker image installs it at build time, and `run.sh` installs or updates it automatically for local runs (checksum-verified into `.venv/bin`, pinned to the same version as the Docker image via the Dockerfile `ARG LITMUS_SDK_CLI_VERSION`). To use a different binary, set `LITMUS_SDK_CLI_PATH` (skips the bootstrap), or install one from the `cli-v*` releases at https://github.com/litmusautomation/litmus-sdk-releases/releases and put it on PATH. They expose the full generated SDK surface beyond the curated tools above. Notes:
 - Connection headers are forwarded to the CLI per call; no CLI profile is read or written.
 - `litmus_sdk_call` can invoke destructive SDK functions (create/update/delete/restart). Every call requires explicit user approval via the `user_approved` argument, which the assistant may only set after you approve the exact function and arguments.
 - Prefer the dedicated tools above when one covers the operation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "influxdb>=5.3.2",
     "jinja2>=3.1.6",
     "litmussdk",
-    "mcp[cli]>=1.17.0",
+    "mcp[cli]>=1.28.1,<2",
     "nats-py>=2.11.0",
     "numpy>=2.3.4",
     "pandas>=2.3.3",

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,79 @@ if [ -f .env ]; then
     source .env
 fi
 
+# Bootstrap the litmus-sdk-cli binary for local (non-Docker) runs, pinned to
+# the same release the Docker image installs (the Dockerfile ARG is the single
+# source of truth). Skipped when LITMUS_SDK_CLI_PATH is already set (e.g. via
+# .env). Failure is non-fatal: only the litmus_sdk_discover and
+# litmus_sdk_call fallback tools need the binary.
+bootstrap_sdk_cli() {
+    TAG=$(sed -n 's/^ARG LITMUS_SDK_CLI_VERSION=//p' Dockerfile)
+    if [ -z "$TAG" ]; then
+        echo "run.sh: could not read LITMUS_SDK_CLI_VERSION from Dockerfile" >&2
+        return 1
+    fi
+
+    TARGET="$PWD/.venv/bin/litmus-sdk-cli"
+    WANT="${TAG#cli-}"
+    if [ -x "$TARGET" ]; then
+        HAVE=$("$TARGET" --version 2>/dev/null | head -1 | awk '{print $2}')
+        if [ "$HAVE" = "$WANT" ]; then
+            export LITMUS_SDK_CLI_PATH="$TARGET"
+            return 0
+        fi
+        echo "run.sh: litmus-sdk-cli $HAVE installed, Dockerfile pins $WANT; updating"
+    fi
+
+    case "$(uname -s)" in
+        Darwin) OS=darwin ;;
+        Linux)  OS=linux ;;
+        *)
+            echo "run.sh: unsupported OS '$(uname -s)' for litmus-sdk-cli bootstrap" >&2
+            return 1
+            ;;
+    esac
+    case "$(uname -m)" in
+        arm64|aarch64) ARCH=arm64 ;;
+        x86_64|amd64)  ARCH=amd64 ;;
+        *)
+            echo "run.sh: unsupported architecture '$(uname -m)' for litmus-sdk-cli bootstrap" >&2
+            return 1
+            ;;
+    esac
+
+    ASSET="litmus-sdk-cli-${OS}-${ARCH}"
+    BASE="https://github.com/litmusautomation/litmus-sdk-releases/releases/download/${TAG}"
+    TMP=$(mktemp -d)
+    echo "run.sh: installing litmus-sdk-cli ${TAG} (${ASSET}) to ${TARGET}"
+    if ! curl -fsSL -o "$TMP/SHA256SUMS" "$BASE/SHA256SUMS" ||
+       ! curl -fsSL -o "$TMP/$ASSET" "$BASE/$ASSET"; then
+        echo "run.sh: download failed for ${BASE}/${ASSET}" >&2
+        rm -rf "$TMP"
+        return 1
+    fi
+    if command -v sha256sum >/dev/null 2>&1; then
+        SHA_CMD="sha256sum"
+    else
+        SHA_CMD="shasum -a 256"
+    fi
+    if ! (cd "$TMP" && grep " ${ASSET}\$" SHA256SUMS | $SHA_CMD -c -); then
+        echo "run.sh: checksum verification failed for ${ASSET}" >&2
+        rm -rf "$TMP"
+        return 1
+    fi
+    mkdir -p "$PWD/.venv/bin"
+    chmod +x "$TMP/$ASSET"
+    mv "$TMP/$ASSET" "$TARGET"
+    rm -rf "$TMP"
+    export LITMUS_SDK_CLI_PATH="$TARGET"
+}
+
+if [ -z "${LITMUS_SDK_CLI_PATH:-}" ]; then
+    if ! bootstrap_sdk_cli; then
+        echo "run.sh: continuing without litmus-sdk-cli; litmus_sdk_discover and litmus_sdk_call will be unavailable" >&2
+    fi
+fi
+
 # Prefer the project venv Python (always present in Docker, present locally after uv sync).
 # This also ensures server.py (spawned as subprocess) uses the same venv via sys.executable.
 if [ -f ".venv/bin/python3" ]; then

--- a/src/server.py
+++ b/src/server.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import asyncio
 import os
@@ -10,6 +11,7 @@ from mcp.server import Server
 
 from mcp.server.sse import SseServerTransport
 from mcp.server.stdio import stdio_server
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from mcp.types import Tool, TextContent
 from mcp.shared.exceptions import McpError
 from mcp.types import ErrorData, INTERNAL_ERROR, METHOD_NOT_FOUND
@@ -106,6 +108,23 @@ async def handle_list_tools() -> list[Tool]:
     ]
 
 
+def _resolve_request():
+    """Resolve the request carrying connection headers for the current tool call.
+
+    Streamable HTTP attaches the Starlette request to each message
+    (mcp.request_context.request); its handlers run in the session manager's
+    task group, where the current_request context var is not set. SSE and
+    stdio set current_request on the connection task instead.
+    """
+    try:
+        ctx_request = mcp.request_context.request
+    except LookupError:
+        ctx_request = None
+    if ctx_request is not None:
+        return ctx_request
+    return current_request.get()
+
+
 @mcp.call_tool()
 async def handle_call_tool(name: str, arguments: dict | None) -> list[TextContent]:
     """Dispatch a tool call by looking up the handler in TOOL_BY_NAME."""
@@ -116,7 +135,7 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[TextConten
             ErrorData(code=METHOD_NOT_FOUND, message=f"Unknown tool: {name}")
         )
 
-    request = current_request.get()
+    request = _resolve_request()
     if request is None:
         raise McpError(
             ErrorData(code=INTERNAL_ERROR, message="Request context not available")
@@ -151,6 +170,34 @@ async def run_stdio_server():
     # Run with stdio transport
     async with stdio_server() as (read_stream, write_stream):
         await mcp.run(read_stream, write_stream, mcp.create_initialization_options())
+
+
+# Streamable HTTP endpoint (spec 2025-03-26+). Stateless: every call carries
+# its own connection headers, so there is no per-session state to keep.
+session_manager = StreamableHTTPSessionManager(
+    app=mcp,
+    event_store=None,
+    json_response=False,
+    stateless=True,
+)
+
+
+class StreamableHTTPEndpoint:
+    """Raw ASGI endpoint for /mcp (a class instance so Starlette's Route does
+    not wrap it in request_response, which would double-send the response)."""
+
+    async def __call__(self, scope, receive, send):
+        await session_manager.handle_request(scope, receive, send)
+
+
+handle_streamable_http = StreamableHTTPEndpoint()
+
+
+@contextlib.asynccontextmanager
+async def lifespan(app):
+    """Run the streamable HTTP session manager for the app's lifetime."""
+    async with session_manager.run():
+        yield
 
 
 # SSE endpoint handler
@@ -263,7 +310,8 @@ async def oauth_not_supported(request: Request):
         content={
             "error": "unsupported_oauth",
             "error_description": "This MCP server does not support OAuth authentication. "
-            "Please use SSE transport with header-based authentication "
+            "Please use the Streamable HTTP (/mcp) or SSE (/sse) transport with "
+            "header-based authentication "
             "(EDGE_API_CLIENT_ID and EDGE_API_CLIENT_SECRET).",
         },
     )
@@ -277,7 +325,7 @@ async def health_check(request: Request):
 # Wrap the SSE POST handler with our context-capturing middleware
 wrapped_post_handler = ContextCapturingMiddleware(sse.handle_post_message)
 
-# Create Starlette app with both SSE and POST message routes
+# Create Starlette app with the Streamable HTTP, SSE and POST message routes
 app = Starlette(
     routes=[
         Route("/sse", endpoint=handle_sse, methods=["GET"]),
@@ -294,12 +342,22 @@ app = Starlette(
             methods=["GET"],
         ),
         Route(
+            "/.well-known/oauth-authorization-server/mcp",
+            endpoint=oauth_not_supported,
+            methods=["GET"],
+        ),
+        Route(
             "/.well-known/openid-configuration",
             endpoint=oauth_not_supported,
             methods=["GET"],
         ),
         Route(
             "/.well-known/openid-configuration/sse",
+            endpoint=oauth_not_supported,
+            methods=["GET"],
+        ),
+        Route(
+            "/.well-known/openid-configuration/mcp",
             endpoint=oauth_not_supported,
             methods=["GET"],
         ),
@@ -318,10 +376,28 @@ app = Starlette(
             endpoint=oauth_not_supported,
             methods=["GET"],
         ),
+        Route(
+            "/.well-known/oauth-protected-resource/mcp",
+            endpoint=oauth_not_supported,
+            methods=["GET"],
+        ),
         Route("/register", endpoint=oauth_not_supported, methods=["GET", "POST"]),
         # Health check endpoint
         Route("/health", endpoint=health_check, methods=["GET"]),
-    ]
+        Route(
+            "/mcp/.well-known/openid-configuration",
+            endpoint=oauth_not_supported,
+            methods=["GET"],
+        ),
+        # Streamable HTTP transport; exact path (no Mount) so clients hitting
+        # /mcp are served directly instead of being 307-redirected to /mcp/
+        Route(
+            "/mcp",
+            endpoint=handle_streamable_http,
+            methods=["POST", "GET", "DELETE"],
+        ),
+    ],
+    lifespan=lifespan,
 )
 
 if __name__ == "__main__":
@@ -333,7 +409,8 @@ if __name__ == "__main__":
         logger.info("STDIO mode enabled")
         asyncio.run(run_stdio_server())
     else:
-        # SSE mode - runs HTTP server (current behavior)
-        logger.info(f"SSE mode enabled - Starting on port {MCP_PORT}")
-        logger.info(f"SSE endpoint: http://0.0.0.0:{MCP_PORT}/sse")
+        # HTTP mode - serves both Streamable HTTP and legacy SSE transports
+        logger.info(f"HTTP mode enabled - Starting on port {MCP_PORT}")
+        logger.info(f"Streamable HTTP endpoint: http://0.0.0.0:{MCP_PORT}/mcp")
+        logger.info(f"SSE endpoint (legacy): http://0.0.0.0:{MCP_PORT}/sse")
         uvicorn.run(app, host="0.0.0.0", port=MCP_PORT)

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,12 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "aiofiles"
@@ -813,7 +819,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.25.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -831,9 +837,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/2d/649d80a0ecf6a1f82632ca44bec21c0461a9d9fc8934d38cb5b319f2db5e/mcp-1.25.0.tar.gz", hash = "sha256:56310361ebf0364e2d438e5b45f7668cbb124e158bb358333cd06e49e83a6802", size = 605387, upload-time = "2025-12-19T10:19:56.985Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/fc/6dc7659c2ae5ddf280477011f4213a74f806862856b796ef08f028e664bf/mcp-1.25.0-py3-none-any.whl", hash = "sha256:b37c38144a666add0862614cc79ec276e97d72aa8ca26d622818d4e278b9721a", size = 233076, upload-time = "2025-12-19T10:19:55.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -671,7 +671,7 @@ requires-dist = [
     { name = "influxdb", specifier = ">=5.3.2" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "litmussdk", url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.7.1/litmussdk-2.7.1-py3-none-any.whl" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.17.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
     { name = "nats-py", specifier = ">=2.11.0" },
     { name = "numpy", specifier = ">=2.3.4" },
     { name = "pandas", specifier = ">=2.3.3" },


### PR DESCRIPTION
Two changes:

**Streamable HTTP transport at /mcp** (src/server.py)
- Serves the current MCP spec transport (2025-03-26+) via StreamableHTTPSessionManager in stateless mode, mounted at the exact /mcp path alongside the legacy /sse + /messages endpoints, per the spec's backwards-compatibility guidance.
- Tool dispatch resolves the request from mcp.request_context.request for streamable HTTP (handlers run in the session manager's task group where the current_request ContextVar does not propagate), falling back to the ContextVar for SSE/stdio. Header-based auth is unchanged.
- Adds /mcp variants of the OAuth well-known routes.

**litmus-sdk-cli bootstrap for local runs** (run.sh)
- run.sh now installs or updates the litmus-sdk-cli binary into .venv/bin, checksum-verified against the release SHA256SUMS and pinned to the Dockerfile ARG LITMUS_SDK_CLI_VERSION, so local uv runs get the same CLI as the Docker image. Skipped when LITMUS_SDK_CLI_PATH is set; failures are non-fatal.

Verified live: initialize/tools/list/tools/call through /mcp (including an Edge-authenticated call with real headers), SDK streamablehttp_client connects (negotiates 2025-11-25), legacy GET /sse still serves the endpoint event, ruff clean, 135 tests pass. run.sh bootstrap tested for fresh install, already-current skip, and stale-version update paths.