### PR TITLE
chore: bump litmussdk to 2.7.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ test = [
 
 
 [tool.uv.sources]
-litmussdk = { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.7.2/litmussdk-2.7.2-py3-none-any.whl" }
+litmussdk = { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.7.3/litmussdk-2.7.3-py3-none-any.whl" }
 
 [tool.ruff]
 exclude = [

--- a/uv.lock
+++ b/uv.lock
@@ -670,7 +670,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "influxdb", specifier = ">=5.3.2" },
     { name = "jinja2", specifier = ">=3.1.6" },
-    { name = "litmussdk", url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.7.2/litmussdk-2.7.2-py3-none-any.whl" },
+    { name = "litmussdk", url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.7.3/litmussdk-2.7.3-py3-none-any.whl" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
     { name = "nats-py", specifier = ">=2.11.0" },
     { name = "numpy", specifier = ">=2.3.4" },
@@ -698,8 +698,8 @@ test = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "litmussdk"
-version = "2.7.2"
-source = { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.7.2/litmussdk-2.7.2-py3-none-any.whl" }
+version = "2.7.3"
+source = { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.7.3/litmussdk-2.7.3-py3-none-any.whl" }
 dependencies = [
     { name = "appdirs" },
     { name = "brotli" },
@@ -714,7 +714,7 @@ dependencies = [
     { name = "urllib3" },
 ]
 wheels = [
-    { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.7.2/litmussdk-2.7.2-py3-none-any.whl", hash = "sha256:7c18caf656f713d61887d0218b1fcc3753196cbd3bc8ae73e9d32d5cdb73180e" },
+    { url = "https://github.com/litmusautomation/litmus-sdk-releases/releases/download/2.7.3/litmussdk-2.7.3-py3-none-any.whl", hash = "sha256:e88286472f485164a3b43a0b4c9c09f20327354156b1061a1ecbb2b835f69860" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
Automated bump triggered by the [2.7.3 SDK release](https://github.com/litmusautomation/litmus-sdk-releases/releases/tag/2.7.3).

Tests passed on the new version before this PR was opened.