### PR TITLE
Pin the ruff rule set and version, sort imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,10 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.12"
-      - run: uvx ruff check .
+      # Pinned via the lint dependency group in uv.lock. An unpinned `uvx ruff`
+      # picks up new releases mid-flight, so ruff 0.16's changed default rule
+      # set failed CI on an unrelated dependency bump.
+      - run: uv run --only-group lint ruff check .
 
   test:
     name: Tests (pytest)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,5 +56,16 @@ exclude = [
 ]
 line-length = 88
 indent-width = 4
+
+[tool.ruff.lint]
+# Selected explicitly rather than relying on ruff's defaults: those changed in
+# ruff 0.16 (new families added, pycodestyle E4 dropped) and broke CI, which
+# ran an unpinned `uvx ruff`. E4/E7/E9/F was the effective set before; the rest
+# are deliberate additions covering the mechanically enforceable rules 0.16
+# surfaced. The judgment-heavy families it also added (BLE, S, SIM, TRY, G,
+# LOG, ASYNC, DTZ, PLW) are not enabled yet; adopting them needs a per-site
+# review, mostly of blind `except Exception` handlers.
+select = ["E4", "E7", "E9", "F", "I", "UP", "RUF", "FURB", "PLR0402"]
+
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/client_utils.py
+++ b/src/client_utils.py
@@ -1,15 +1,14 @@
 import os
-from typing import Optional, Iterable, cast
+from collections.abc import Iterable
 from contextlib import AsyncExitStack, asynccontextmanager
-from mcp import ClientSession
-from mcp.client.sse import sse_client
+from typing import cast
 
+from agents import Agent, ModelSettings, Runner, gen_trace_id, trace
+from agents.mcp import MCPServerSse
 from anthropic import AsyncAnthropic
 from anthropic.types import MessageParam, ToolParam
-
-from agents import Agent, Runner, gen_trace_id, trace
-from agents.mcp import MCPServerSse
-from agents import ModelSettings
+from mcp import ClientSession
+from mcp.client.sse import sse_client
 
 from env_config import (
     CLIENT_SESSION_TIMEOUT_SECONDS,
@@ -80,7 +79,7 @@ _system_prompt = (
 
 class MCPClient:
     def __init__(self):
-        self.anthropic: Optional[AsyncAnthropic] = None
+        self.anthropic: AsyncAnthropic | None = None
         self._anthropic_key: str = ""
         self.model_used = None
 

--- a/src/conversation.py
+++ b/src/conversation.py
@@ -2,7 +2,7 @@
 Per-session conversation history and chat utilities.
 """
 
-from typing import List, Dict, Any, Tuple
+from typing import Any
 
 # Maximum number of user/assistant pairs to keep per session
 MAX_HISTORY_PAIRS = 5
@@ -14,7 +14,7 @@ _SESSIONS: dict[str, list] = {}
 STREAMING_ALLOWED = True
 
 
-def get_conversation_history(session_id: str) -> List[Dict[str, Any]]:
+def get_conversation_history(session_id: str) -> list[dict[str, Any]]:
     """Return a copy of the conversation history for the given session."""
     return list(_SESSIONS.get(session_id, []))
 
@@ -35,7 +35,7 @@ def update_conversation_history(
         _SESSIONS[session_id] = history[-MAX_HISTORY_PAIRS * 2 :]
 
 
-def get_chat_log(conversation_history: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def get_chat_log(conversation_history: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Format raw conversation history into user/assistant display pairs."""
     chat_log = []
     for i in range(0, len(conversation_history), 2):
@@ -49,7 +49,7 @@ def get_chat_log(conversation_history: List[Dict[str, Any]]) -> List[Dict[str, A
     return chat_log
 
 
-def check_streaming_status(current_route: str) -> Tuple[bool, str]:
+def check_streaming_status(current_route: str) -> tuple[bool, str]:
     redirect = False
     new_route = current_route
 

--- a/src/env_config.py
+++ b/src/env_config.py
@@ -5,9 +5,9 @@ Handles .env file I/O, credential loading, Edge instance management,
 and model/API key selection.
 """
 
-import os
 import logging
-from typing import Tuple
+import os
+
 import dotenv
 
 # ── Path constants ──────────────────────────────────────────────────────────
@@ -103,7 +103,7 @@ def _get_env_vars(env_file, override):
     env_vars = {}
 
     if os.path.exists(path_to_env):
-        with open(path_to_env, "r") as file:
+        with open(path_to_env) as file:
             for line in file:
                 if "=" in line:
                     k, v = line.strip().split("=", 1)
@@ -120,8 +120,7 @@ def mcp_env_remover(key: str, env_file: str = ".env"):
 
     env_vars.pop(key, None)
     with open(path_to_env, "w") as file:
-        for k, v in env_vars.items():
-            file.write(f"{k}={v}\n")
+        file.writelines(f"{k}={v}\n" for k, v in env_vars.items())
 
     print(f"Removed {key} in {env_file}")
 
@@ -131,8 +130,7 @@ def mcp_env_updater(key: str, value: str | bool, env_file: str = ".env"):
     env_vars[key] = value
 
     with open(path_to_env, "w") as file:
-        for k, v in env_vars.items():
-            file.write(f"{k}={v}\n")
+        file.writelines(f"{k}={v}\n" for k, v in env_vars.items())
 
     print(f"Updated {key} in {env_file}")
 
@@ -314,7 +312,7 @@ def migrate_legacy_lem_settings():
 # ── Model / API key selection ───────────────────────────────────────────────
 
 
-def check_model_key() -> Tuple[bool, str]:
+def check_model_key() -> tuple[bool, str]:
     anthropic_exists = os.environ.get(key_of_anthropic_api_key)
     openai_exists = os.environ.get(key_of_openai_api_key)
     gemini_exists = os.environ.get(key_of_gemini_api_key)

--- a/src/server.py
+++ b/src/server.py
@@ -1,41 +1,45 @@
+import asyncio
 import base64
 import contextlib
 import copy
 import logging
-import asyncio
 import os
 import warnings
-
 from contextvars import ContextVar
 from pathlib import Path as _Path
 
 import urllib3
 from mcp.server import Server
-
 from mcp.server.sse import SseServerTransport
 from mcp.server.stdio import stdio_server
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
-from mcp.types import Icon, Tool, TextContent
 from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, INTERNAL_ERROR, METHOD_NOT_FOUND
+from mcp.types import (
+    INTERNAL_ERROR,
+    METHOD_NOT_FOUND,
+    ErrorData,
+    Icon,
+    TextContent,
+    Tool,
+)
 from starlette.applications import Starlette
-from starlette.routing import Route, Mount
 from starlette.requests import Request
-from starlette.responses import Response, JSONResponse
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Mount, Route
 
 from config import MCP_PORT, server_version
-from tools.devicehub_tools import TOOLS as _DH_TOOLS
-from tools.dm_tools import TOOLS as _DM_TOOLS
-from tools.marketplace_tools import TOOLS as _MKT_TOOLS
 from tools.data_tools import TOOLS as _DATA_TOOLS
+from tools.devicehub_tools import TOOLS as _DH_TOOLS
 from tools.digitaltwins_tools import TOOLS as _DT_TOOLS
-from tools.system_tools import TOOLS as _SYS_TOOLS
+from tools.dm_tools import TOOLS as _DM_TOOLS
 from tools.lem_tools import TOOLS as _LEM_TOOLS
-from tools.sdk_cli_tools import TOOLS as _SDK_CLI_TOOLS
+from tools.marketplace_tools import TOOLS as _MKT_TOOLS
 from tools.resource_tools import (
     get_documentation_resource_list,
     read_documentation_resource,
 )
+from tools.sdk_cli_tools import TOOLS as _SDK_CLI_TOOLS
+from tools.system_tools import TOOLS as _SYS_TOOLS
 
 ALL_TOOLS = (
     _DH_TOOLS
@@ -276,7 +280,7 @@ async def handle_call_tool(name: str, arguments: dict | None) -> list[TextConten
         raise McpError(
             ErrorData(
                 code=INTERNAL_ERROR,
-                message=f"Tool execution failed: {str(e)}",
+                message=f"Tool execution failed: {e!s}",
             )
         ) from e
 
@@ -528,6 +532,7 @@ app = Starlette(
 
 if __name__ == "__main__":
     import uvicorn
+
     from config import ENABLE_STDIO
 
     if ENABLE_STDIO:

--- a/src/tools/data_tools.py
+++ b/src/tools/data_tools.py
@@ -1,29 +1,32 @@
 import asyncio
 import difflib
-import re
-import nats
 import json
-import pandas as pd
-from typing import Optional
+import re
 from datetime import datetime
 
-from config import logger, ssl_config
-
-from utils.formatting import format_success_response, format_error_response
-from utils.auth import (
-    get_nats_connection_params,
-    get_influx_connection_params,
-    get_litmus_connection,
+import influxdb
+import nats
+import pandas as pd
+from litmussdk.devicehub import devices as dh_devices
+from litmussdk.devicehub import tags as dh_tags
+from mcp.shared.exceptions import McpError
+from mcp.types import (
+    INTERNAL_ERROR,
+    INVALID_PARAMS,
+    ErrorData,
+    TextContent,
+    ToolAnnotations,
 )
-
 from numpy import zeros
 from starlette.requests import Request
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, INVALID_PARAMS, INTERNAL_ERROR
-from mcp.types import TextContent, ToolAnnotations
 
-import influxdb
-from litmussdk.devicehub import devices as dh_devices, tags as dh_tags
+from config import logger, ssl_config
+from utils.auth import (
+    get_influx_connection_params,
+    get_litmus_connection,
+    get_nats_connection_params,
+)
+from utils.formatting import format_error_response, format_success_response
 
 INFLUXDB_AVAILABLE = True
 
@@ -31,7 +34,7 @@ INFLUXDB_AVAILABLE = True
 NATS_TIMEOUT = 30  # seconds
 
 
-def _nats_connection_note(params: dict) -> Optional[str]:
+def _nats_connection_note(params: dict) -> str | None:
     """Human/LLM-facing note when the broker address was derived from EDGE_URL."""
     if params.get("derived_from_edge_url"):
         return (
@@ -43,7 +46,7 @@ def _nats_connection_note(params: dict) -> Optional[str]:
     return None
 
 
-def _influx_connection_note(params: dict) -> Optional[str]:
+def _influx_connection_note(params: dict) -> str | None:
     """Human/LLM-facing note when the InfluxDB address was derived from EDGE_URL."""
     if params.get("derived_from_edge_url"):
         return (
@@ -55,21 +58,21 @@ def _influx_connection_note(params: dict) -> Optional[str]:
     return None
 
 
-def _with_connection_note(result: dict, note: Optional[str]) -> dict:
+def _with_connection_note(result: dict, note: str | None) -> dict:
     if note:
         result["connection_note"] = note
     return result
 
 
-def _error_with_note(message: str, note: Optional[str]) -> str:
+def _error_with_note(message: str, note: str | None) -> str:
     return f"{message} ({note})" if note else message
 
 
 async def get_current_value_on_topic(
     topic: str,
-    nats_source: Optional[str] = None,
-    nats_port: Optional[str] = None,
-    request: Optional[Request] = None,
+    nats_source: str | None = None,
+    nats_port: str | None = None,
+    request: Request | None = None,
 ) -> dict:
     """
     Subscribes to a NATS topic and retrieves the next published message.
@@ -238,9 +241,9 @@ async def _nc_single_topic(
     nats_port: str,
     nats_subscription_topic: str,
     stop_event: asyncio.Event,
-    nats_user: Optional[str] = None,
-    nats_password: Optional[str] = None,
-    nats_token: Optional[str] = None,
+    nats_user: str | None = None,
+    nats_password: str | None = None,
+    nats_token: str | None = None,
     use_tls: bool = True,
 ) -> dict:
     """
@@ -274,7 +277,7 @@ async def _nc_single_topic(
         await nc.subscribe(nats_subscription_topic, cb=message_handler)
         try:
             await asyncio.wait_for(stop_event.wait(), timeout=NATS_TIMEOUT)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             raise McpError(
                 ErrorData(
                     code=INTERNAL_ERROR,
@@ -300,9 +303,9 @@ async def _collect_multiple_values_from_topic(
     topic: str,
     stop_event: asyncio.Event,
     num_samples: int = 10,
-    nats_user: Optional[str] = None,
-    nats_password: Optional[str] = None,
-    nats_token: Optional[str] = None,
+    nats_user: str | None = None,
+    nats_password: str | None = None,
+    nats_token: str | None = None,
     use_tls: bool = True,
 ) -> dict:
     """
@@ -350,7 +353,7 @@ async def _collect_multiple_values_from_topic(
         await nc.subscribe(topic, cb=message_handler)
         try:
             await asyncio.wait_for(stop_event.wait(), timeout=NATS_TIMEOUT)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             raise McpError(
                 ErrorData(
                     code=INTERNAL_ERROR,
@@ -518,7 +521,7 @@ def _list_measurement_names(client) -> list[str]:
     return [pt["name"] for pt in points if isinstance(pt, dict) and "name" in pt]
 
 
-def _device_measurement_name(measurement_names: list, device) -> Optional[str]:
+def _device_measurement_name(measurement_names: list, device) -> str | None:
     """Resolve the measurement holding a device's tag data.
 
     Modern LE writes ALL of a device's registers into one measurement named
@@ -538,7 +541,7 @@ def _device_measurement_name(measurement_names: list, device) -> Optional[str]:
 
 def _tag_data_source(
     measurement_names: list, device, tag
-) -> tuple[Optional[str], str]:
+) -> tuple[str | None, str]:
     """Return (measurement, where_prefix) for reading one tag's history.
 
     Prefers a legacy per-topic measurement when one exists; otherwise the
@@ -566,7 +569,7 @@ def _find_device(connection, device_name: str):
     return None
 
 
-def _get_output_topic(tag) -> Optional[str]:
+def _get_output_topic(tag) -> str | None:
     for tp in tag.topics or []:
         if tp.direction == "Output":
             return tp.topic

--- a/src/tools/devicehub_tools.py
+++ b/src/tools/devicehub_tools.py
@@ -1,33 +1,39 @@
 import asyncio
 import time
-from datetime import datetime, timezone
-from typing import Optional, Any
+from datetime import UTC, datetime
+from typing import Any
+
+from litmussdk.devicehub import devices, tags
+from litmussdk.devicehub.drivers import list_all_drivers
+from litmussdk.devicehub.tags import Tag
+from litmussdk.utils import api, api_paths, gql_queries
+from mcp.shared.exceptions import McpError
+from mcp.types import (
+    INTERNAL_ERROR,
+    INVALID_PARAMS,
+    ErrorData,
+    TextContent,
+    ToolAnnotations,
+)
+from starlette.requests import Request
+
 from config import logger
-from utils.auth import get_litmus_connection, get_influx_connection_params
+from utils.auth import get_influx_connection_params, get_litmus_connection
 from utils.formatting import (
-    format_success_response,
     format_error_response,
+    format_success_response,
     redact_secrets,
 )
+
 from .data_tools import (
-    get_current_value_on_topic,
-    _make_influx_client,
-    _influx_connection_note,
-    _with_connection_note,
-    _list_measurement_names,
     _device_measurement_name,
+    _influx_connection_note,
+    _list_measurement_names,
+    _make_influx_client,
+    _with_connection_note,
+    get_current_value_on_topic,
 )
-
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, INVALID_PARAMS, INTERNAL_ERROR
-from mcp.types import TextContent, ToolAnnotations
-from starlette.requests import Request
-from litmussdk.devicehub import devices, tags
-from litmussdk.devicehub.tags import Tag
-from litmussdk.devicehub.drivers import list_all_drivers
-from litmussdk.utils import api, api_paths, gql_queries
-
-from .sdk_cli_tools import run_cli_function, CLIFunctionError
+from .sdk_cli_tools import CLIFunctionError, run_cli_function
 
 # Short-lived cache for the device list, keyed by EDGE_URL.
 # Avoids redundant API round-trips when the LLM calls multiple device tools
@@ -536,7 +542,7 @@ async def get_current_value_of_devicehub_tag(
 
 def _find_device_by_name(
     connection: Any, device_name: str, request=None
-) -> Optional[Any]:
+) -> Any | None:
     """Find a device by name, using a short-lived cache to avoid redundant API calls.
 
     A cache miss on the name triggers one fresh fetch: a device created
@@ -690,8 +696,8 @@ async def get_device_connection_status(
                     if not pts:
                         continue
                     ts_str = pts[0].get("time", "")
-                    ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
-                    ts_epoch = ts.replace(tzinfo=timezone.utc).timestamp()
+                    ts = datetime.fromisoformat(ts_str)
+                    ts_epoch = ts.replace(tzinfo=UTC).timestamp()
                     if newest_ts is None or ts_epoch > newest_ts:
                         newest_ts = ts_epoch
                         last_seen = ts_str

--- a/src/tools/digitaltwins_tools.py
+++ b/src/tools/digitaltwins_tools.py
@@ -1,22 +1,22 @@
 import asyncio
 
-from starlette.requests import Request
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, INVALID_PARAMS
-from mcp.types import TextContent, ToolAnnotations
-
 from litmussdk.digital_twins import (
-    list_models,
-    create_model,
-    list_all_instances,
     create_instance,
+    create_model,
     get_hierarchy,
+    list_all_instances,
+    list_models,
 )
 from litmussdk.utils import api, api_paths, gql_queries
-from utils.auth import get_litmus_connection
-from utils.formatting import format_success_response, format_error_response
+from mcp.shared.exceptions import McpError
+from mcp.types import INVALID_PARAMS, ErrorData, TextContent, ToolAnnotations
+from starlette.requests import Request
+
 from config import logger
-from .sdk_cli_tools import run_cli_function, CLIFunctionError
+from utils.auth import get_litmus_connection
+from utils.formatting import format_error_response, format_success_response
+
+from .sdk_cli_tools import CLIFunctionError, run_cli_function
 
 
 async def list_digital_twin_models_tool(

--- a/src/tools/dm_tools.py
+++ b/src/tools/dm_tools.py
@@ -1,12 +1,11 @@
+from litmussdk.system import device_management, network
+from mcp.shared.exceptions import McpError
+from mcp.types import INVALID_PARAMS, ErrorData, TextContent, ToolAnnotations
+from starlette.requests import Request
+
 from config import logger
 from utils.auth import get_litmus_connection
-from utils.formatting import format_success_response, format_error_response
-
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, INVALID_PARAMS
-from mcp.types import TextContent, ToolAnnotations
-from starlette.requests import Request
-from litmussdk.system import network, device_management
+from utils.formatting import format_error_response, format_success_response
 
 
 async def get_litmusedge_friendly_name(

--- a/src/tools/lem_tools.py
+++ b/src/tools/lem_tools.py
@@ -1,14 +1,9 @@
-from starlette.requests import Request
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, INVALID_PARAMS, TextContent, ToolAnnotations
-
-from litmussdk.lem.lifecycle.edgedevs.general import (
-    get_devices_paginated,
-    get_current_device_details,
-    get_device_versions,
-    get_device_tags,
-    get_license_expiry_in_x_days,
-    get_expired_licenses,
+from litmussdk.devicehub import devices as devicehub_devices
+from litmussdk.lem.companies import (
+    get_company_details,
+    get_company_projects,
+    get_project_details,
+    list_all_company_stats,
 )
 from litmussdk.lem.lifecycle.dashboard import (
     dashboard_usage,
@@ -16,24 +11,27 @@ from litmussdk.lem.lifecycle.dashboard import (
     get_project_alerts,
     get_system_time,
 )
-from litmussdk.lem.companies import (
-    list_all_company_stats,
-    get_company_details,
-    get_company_projects,
-    get_project_details,
+from litmussdk.lem.lifecycle.edgedevs.general import (
+    get_current_device_details,
+    get_device_tags,
+    get_device_versions,
+    get_devices_paginated,
+    get_expired_licenses,
+    get_license_expiry_in_x_days,
 )
+from litmussdk.system import device_management, network
 from litmussdk.utils.conn import new_lem_bridge_connection
-from litmussdk.devicehub import devices as devicehub_devices
-from litmussdk.system import network, device_management
-from config import DEFAULT_TIMEOUT
+from mcp.shared.exceptions import McpError
+from mcp.types import INVALID_PARAMS, ErrorData, TextContent, ToolAnnotations
+from starlette.requests import Request
 
+from config import DEFAULT_TIMEOUT, logger
 from utils.auth import get_lem_connection, get_lem_project_id
 from utils.formatting import (
-    format_success_response,
     format_error_response,
+    format_success_response,
     redact_secrets,
 )
-from config import logger
 
 
 async def lem_list_devices_tool(

--- a/src/tools/marketplace_tools.py
+++ b/src/tools/marketplace_tools.py
@@ -1,12 +1,11 @@
-from config import logger
-from starlette.requests import Request
-from mcp.types import TextContent, ToolAnnotations
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, INVALID_PARAMS
 from litmussdk.marketplace import list_all_containers, run_container
+from mcp.shared.exceptions import McpError
+from mcp.types import INVALID_PARAMS, ErrorData, TextContent, ToolAnnotations
+from starlette.requests import Request
 
+from config import logger
 from utils.auth import get_litmus_connection
-from utils.formatting import format_success_response, format_error_response
+from utils.formatting import format_error_response, format_success_response
 
 
 async def get_all_containers_on_litmusedge(

--- a/src/tools/resource_tools.py
+++ b/src/tools/resource_tools.py
@@ -7,6 +7,7 @@ such as documentation, configuration files, or other contextual data.
 
 import logging
 from typing import Any
+
 import httpx
 from mcp.types import TextContent
 
@@ -133,10 +134,10 @@ async def fetch_documentation_content(url: str) -> str:
 
     except httpx.HTTPError as e:
         logger.error(f"Error fetching documentation from {url}: {e}")
-        return f"Error fetching documentation: {str(e)}"
+        return f"Error fetching documentation: {e!s}"
     except Exception as e:
         logger.error(f"Unexpected error fetching {url}: {e}")
-        return f"Error: {str(e)}"
+        return f"Error: {e!s}"
 
 
 async def read_documentation_resource(uri: str) -> list[TextContent]:

--- a/src/tools/sdk_cli_tools.py
+++ b/src/tools/sdk_cli_tools.py
@@ -35,15 +35,19 @@ import shutil
 import tempfile
 import urllib.request
 from pathlib import Path
-from typing import Optional
 
-from starlette.requests import Request
 from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, INVALID_PARAMS, INTERNAL_ERROR
-from mcp.types import TextContent, ToolAnnotations
+from mcp.types import (
+    INTERNAL_ERROR,
+    INVALID_PARAMS,
+    ErrorData,
+    TextContent,
+    ToolAnnotations,
+)
+from starlette.requests import Request
 
 from config import logger
-from utils.formatting import format_success_response, format_error_response
+from utils.formatting import format_error_response, format_success_response
 
 # Request headers forwarded verbatim to the CLI environment. The CLI resolves
 # config as profile < .env < environment < flags, so these always win over
@@ -71,7 +75,7 @@ _LEM_BRIDGE_HEADERS = (
 _CLI_TIMEOUT_SECONDS = 120
 _RELEASES_URL = "https://github.com/litmusautomation/litmus-sdk-releases/releases"
 
-_isolated_dir: Optional[str] = None
+_isolated_dir: str | None = None
 
 
 def _get_isolated_dir() -> str:
@@ -100,7 +104,7 @@ _BOOTSTRAP_BASE_DIR = Path.home() / ".cache" / "litmus-mcp-server" / "bin"
 
 _DOWNLOAD_TIMEOUT_SECONDS = 60
 
-_bootstrap_lock: Optional[asyncio.Lock] = None
+_bootstrap_lock: asyncio.Lock | None = None
 
 
 def _pinned_cli_version() -> str:
@@ -141,7 +145,7 @@ def _cli_asset_name() -> str:
     return f"litmus-cli-{os_name}-{arch}{suffix}"
 
 
-def _bootstrap_target(tag: Optional[str] = None) -> Path:
+def _bootstrap_target(tag: str | None = None) -> Path:
     """Version-scoped install path, so a pin bump re-downloads naturally."""
     name = "litmus-cli.exe" if platform.system() == "Windows" else "litmus-cli"
     return _BOOTSTRAP_BASE_DIR / (tag or _pinned_cli_version()) / name
@@ -157,7 +161,7 @@ def version_key(text: str) -> tuple:
     return tuple(int(x) for x in re.findall(r"\d+", text or ""))
 
 
-def get_latest_cli_tag() -> Optional[str]:
+def get_latest_cli_tag() -> str | None:
     """Newest cli-v* release tag from the litmus-sdk-releases repo, or None
     when none are visible. Blocking; run in a thread."""
     api_url = (
@@ -189,7 +193,7 @@ async def upgrade_cli_binary() -> tuple:
     return tag, path
 
 
-def _bootstrap_cli_binary(tag: Optional[str] = None) -> str:
+def _bootstrap_cli_binary(tag: str | None = None) -> str:
     """Download a litmus-cli release (the pin by default), verify its SHA256
     against the release's SHA256SUMS, and install it under the user cache
     dir. Blocking; run in a thread."""
@@ -345,7 +349,7 @@ async def _run_cli(argv: list, env: dict) -> tuple:
         stdout, stderr = await asyncio.wait_for(
             process.communicate(), timeout=_CLI_TIMEOUT_SECONDS
         )
-    except asyncio.TimeoutError:
+    except TimeoutError:
         process.kill()
         await process.wait()
         raise McpError(

--- a/src/tools/system_tools.py
+++ b/src/tools/system_tools.py
@@ -2,18 +2,22 @@ import platform
 import time
 from importlib import metadata as importlib_metadata
 
-from config import logger, server_version
-from utils.auth import get_litmus_connection
-from utils.formatting import format_success_response, format_error_response
-
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, INVALID_PARAMS, TextContent, ToolAnnotations
-from starlette.requests import Request
 from litmussdk.system import (
     events as sys_events,
-    network as sys_network,
+)
+from litmussdk.system import (
     general as sys_general,
 )
+from litmussdk.system import (
+    network as sys_network,
+)
+from mcp.shared.exceptions import McpError
+from mcp.types import INVALID_PARAMS, ErrorData, TextContent, ToolAnnotations
+from starlette.requests import Request
+
+from config import logger, server_version
+from utils.auth import get_litmus_connection
+from utils.formatting import format_error_response, format_success_response
 
 
 async def get_system_events_tool(
@@ -179,11 +183,11 @@ async def get_mcp_server_info(
     import json as _json
 
     from tools.sdk_cli_tools import (
-        _resolve_cli_binary,
-        _run_cli,
         _build_cli_env,
         _fetch,
         _pinned_cli_version,
+        _resolve_cli_binary,
+        _run_cli,
         get_latest_cli_tag,
         upgrade_cli_binary,
         version_key,

--- a/src/utils/auth.py
+++ b/src/utils/auth.py
@@ -1,9 +1,5 @@
-from typing import Any, Optional
-from starlette.requests import Request
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, INVALID_PARAMS, INTERNAL_ERROR
 import logging
-
+from typing import Any
 from urllib.parse import urlparse
 
 from litmussdk.utils.conn import (
@@ -11,6 +7,10 @@ from litmussdk.utils.conn import (
     new_lem_bridge_connection,
     new_lem_connection,
 )
+from mcp.shared.exceptions import McpError
+from mcp.types import INTERNAL_ERROR, INVALID_PARAMS, ErrorData
+from starlette.requests import Request
+
 from config import DEFAULT_TIMEOUT, NATS_PORT
 
 logger = logging.getLogger(__name__)
@@ -59,7 +59,7 @@ def get_litmus_connection(request: Request) -> Any:
             raise McpError(
                 ErrorData(
                     code=INTERNAL_ERROR,
-                    message=f"Failed to connect via LEM bridge: {str(e)}",
+                    message=f"Failed to connect via LEM bridge: {e!s}",
                 )
             ) from e
 
@@ -102,7 +102,7 @@ def get_litmus_connection(request: Request) -> Any:
         raise McpError(
             ErrorData(
                 code=INTERNAL_ERROR,
-                message=f"Failed to connect to Litmus Edge: {str(e)}",
+                message=f"Failed to connect to Litmus Edge: {e!s}",
             )
         ) from e
 
@@ -166,7 +166,7 @@ def get_lem_connection(request: Request) -> Any:
         raise McpError(
             ErrorData(
                 code=INTERNAL_ERROR,
-                message=f"Failed to connect to Litmus Edge Manager: {str(e)}",
+                message=f"Failed to connect to Litmus Edge Manager: {e!s}",
             )
         ) from e
 
@@ -212,7 +212,7 @@ def _validate_auth_headers(edge_url: str, client_id: str, client_secret: str) ->
         )
 
 
-def _data_plane_host(raw: Optional[str]) -> Optional[str]:
+def _data_plane_host(raw: str | None) -> str | None:
     """Extract the bare hostname from an address such as
     'https://edge.example.com:8443', '10.0.0.5:443', or 'edge.example.com/'.
     Returns None when nothing parseable was given."""
@@ -227,7 +227,7 @@ def _data_plane_host(raw: Optional[str]) -> Optional[str]:
         return None
 
 
-def get_nats_connection_params(request: Optional[Request] = None) -> dict:
+def get_nats_connection_params(request: Request | None = None) -> dict:
     """
     Get NATS connection parameters from request headers.
 

--- a/src/utils/formatting.py
+++ b/src/utils/formatting.py
@@ -1,5 +1,6 @@
 import json
 import re
+
 from mcp.types import TextContent
 
 

--- a/src/web_client.py
+++ b/src/web_client.py
@@ -1,69 +1,69 @@
-import os
-import secrets
 import asyncio
 import logging
-import warnings
-import urllib3
-from contextlib import asynccontextmanager
-
-from fastapi import FastAPI, Request, Form, HTTPException
-from fastapi.exception_handlers import http_exception_handler
-from fastapi.responses import (
-    HTMLResponse,
-    RedirectResponse,
-    StreamingResponse,
-    JSONResponse,
-)
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.templating import Jinja2Templates
-from fastapi.staticfiles import StaticFiles
-from starlette.exceptions import HTTPException as StarletteHTTPException
-from starlette.status import HTTP_303_SEE_OTHER
-import uvicorn
-from anthropic import AsyncAnthropic
+import os
+import secrets
 import subprocess
 import sys
+import warnings
+from contextlib import asynccontextmanager
 
+import urllib3
+import uvicorn
+from anthropic import AsyncAnthropic
+from fastapi import FastAPI, Form, HTTPException, Request
+from fastapi.exception_handlers import http_exception_handler
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import (
+    HTMLResponse,
+    JSONResponse,
+    RedirectResponse,
+    StreamingResponse,
+)
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.status import HTTP_303_SEE_OTHER
+
+from client_utils import MCPClient
+from conversation import (
+    clear_all_sessions,
+    get_chat_log,
+    get_conversation_history,
+    markdown_to_html,
+    update_conversation_history,
+)
 from env_config import (
-    mcp_env_loader,
-    mcp_env_updater,
-    mcp_env_remover,
-    key_of_anthropic_api_key,
-    key_of_openai_api_key,
-    key_of_gemini_api_key,
-    check_model_key,
-    MODEL_NAME_ANTHROPIC,
-    MODEL_NAME_OPENAI,
-    MODEL_NAME_GEMINI,
-    MODEL_PREFERENCE,
-    PREFERRED_MODEL_ID,
     ACTIVE_EDGE_INSTANCE,
     ACTIVE_LEM_CONNECTION,
     CLIENT_SESSION_TIMEOUT_SECONDS,
-    CLIENT_SESSION_TIMEOUT_SECONDS_MIN,
     CLIENT_SESSION_TIMEOUT_SECONDS_MAX,
-    SAVE_SETTINGS_ALLOWED_KEYS,
-    get_edge_instances,
-    next_edge_instance_index,
-    remove_edge_instance,
-    activate_edge_instance,
-    get_lem_connections,
-    next_lem_connection_index,
-    remove_lem_connection,
-    activate_lem_connection,
+    CLIENT_SESSION_TIMEOUT_SECONDS_MIN,
     JINJA_TEMPLATE_DIR,
+    MODEL_NAME_ANTHROPIC,
+    MODEL_NAME_GEMINI,
+    MODEL_NAME_OPENAI,
+    MODEL_PREFERENCE,
+    PREFERRED_MODEL_ID,
+    SAVE_SETTINGS_ALLOWED_KEYS,
     STATIC_DIR,
+    activate_edge_instance,
+    activate_lem_connection,
+    check_model_key,
+    get_edge_instances,
+    get_lem_connections,
+    key_of_anthropic_api_key,
+    key_of_gemini_api_key,
+    key_of_openai_api_key,
+    mcp_env_loader,
+    mcp_env_remover,
+    mcp_env_updater,
+    next_edge_instance_index,
+    next_lem_connection_index,
+    remove_edge_instance,
+    remove_lem_connection,
 )
-from conversation import (
-    get_conversation_history,
-    update_conversation_history,
-    get_chat_log,
-    markdown_to_html,
-    clear_all_sessions,
-)
-from client_utils import MCPClient
-from tools.resource_tools import DOCUMENTATION_RESOURCES
 from server import ALL_TOOLS
+from tools.resource_tools import DOCUMENTATION_RESOURCES
 
 warnings.filterwarnings("ignore", category=urllib3.exceptions.InsecureRequestWarning)
 logging.basicConfig(
@@ -471,8 +471,9 @@ async def api_add_edge_instance(
 
         def _fetch_name_lem():
             import json as _json
-            from litmussdk.utils.conn import new_lem_bridge_connection
+
             from litmussdk.utils.api import direct_request
+            from litmussdk.utils.conn import new_lem_bridge_connection
 
             conn = new_lem_bridge_connection(
                 edge_manager_url=manager_url,
@@ -537,8 +538,9 @@ async def api_add_edge_instance(
 
     def _fetch_name():
         import json as _json
-        from litmussdk.utils.conn import new_le_connection
+
         from litmussdk.utils.api import direct_request
+        from litmussdk.utils.conn import new_le_connection
 
         conn = new_le_connection(
             edge_url=url,
@@ -764,11 +766,13 @@ async def api_lem_test():
     validate_cert = os.environ.get("VALIDATE_CERTIFICATE", "false").lower() == "true"
 
     def _probe():
+        from litmussdk.lem.companies import list_all_company_stats as _stats
         from litmussdk.lem.lifecycle.dashboard import (
             deployment_info as _deploy,
+        )
+        from litmussdk.lem.lifecycle.dashboard import (
             get_system_time as _time,
         )
-        from litmussdk.lem.companies import list_all_company_stats as _stats
 
         conn = _build_lem_connection(manager_url, api_token, validate_cert)
         out = {"status": "ok"}
@@ -1061,6 +1065,7 @@ async def health_check(request: Request):
 def _run_health_checks(connection, base_url: str) -> dict:
     """Run all service health checks using the given connection and base URL."""
     import json as _json
+
     from litmussdk.utils.api import direct_request
 
     def _get(path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,11 @@
 Pytest configuration and shared fixtures for Litmus MCP Server tests
 """
 
-import pytest
-import sys
 import os
-from unittest.mock import Mock, MagicMock
+import sys
+from unittest.mock import MagicMock, Mock
+
+import pytest
 
 # Add src directory to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -5,17 +5,18 @@ Tests the header-based authentication system that extracts credentials
 from MCP request headers and creates isolated connections.
 """
 
-import pytest
-from unittest.mock import Mock, patch, MagicMock
-from starlette.requests import Request
-
-import sys
 import os
+import sys
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from starlette.requests import Request
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from utils.auth import get_litmus_connection
 from mcp.shared.exceptions import McpError
+
+from utils.auth import get_litmus_connection
 
 # ==================== Test: Valid Authentication ====================
 

--- a/tests/test_bridge_routing.py
+++ b/tests/test_bridge_routing.py
@@ -21,8 +21,8 @@ from server import (  # noqa: E402
     _is_bridgeable,
     _with_bridge_args,
 )
-from utils.auth import get_litmus_connection  # noqa: E402
 from tools.sdk_cli_tools import _build_cli_env  # noqa: E402
+from utils.auth import get_litmus_connection  # noqa: E402
 
 
 def _make_request(headers):

--- a/tests/test_cli_backed_tools.py
+++ b/tests/test_cli_backed_tools.py
@@ -19,14 +19,14 @@ if str(SRC) not in sys.path:
 
 from mcp.shared.exceptions import McpError  # noqa: E402
 
-import tools.digitaltwins_tools as dt_tools  # noqa: E402
 import tools.devicehub_tools as dh_tools  # noqa: E402
+import tools.digitaltwins_tools as dt_tools  # noqa: E402
+from tools.devicehub_tools import get_all_tags_status, get_tag_status  # noqa: E402
 from tools.digitaltwins_tools import (  # noqa: E402
-    list_static_attributes_tool,
     list_dynamic_attributes_tool,
+    list_static_attributes_tool,
     list_transformations_tool,
 )
-from tools.devicehub_tools import get_tag_status, get_all_tags_status  # noqa: E402
 from tools.sdk_cli_tools import CLIFunctionError  # noqa: E402
 
 

--- a/tests/test_connection_fallback.py
+++ b/tests/test_connection_fallback.py
@@ -17,15 +17,15 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from mcp.shared.exceptions import McpError
 
-from utils.auth import (
-    _data_plane_host,
-    get_nats_connection_params,
-    get_influx_connection_params,
-)
 from tools.data_tools import (
     _get_connect_options,
-    _nats_connection_note,
     _influx_connection_note,
+    _nats_connection_note,
+)
+from utils.auth import (
+    _data_plane_host,
+    get_influx_connection_params,
+    get_nats_connection_params,
 )
 
 

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -13,8 +13,9 @@ Key cases:
 
 import os
 import sys
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
@@ -25,8 +26,7 @@ from env_config import _get_env_vars
 
 def _write_env(path, content: dict):
     with open(path, "w") as f:
-        for k, v in content.items():
-            f.write(f"{k}={v}\n")
+        f.writelines(f"{k}={v}\n" for k, v in content.items())
 
 
 # ── Fix A: branch taken when .env is not found ─────────────────────────────
@@ -235,7 +235,7 @@ class TestLemConnectionHelpers:
         assert next_lem_connection_index() == 3
 
     def test_activate_lem_connection_writes_main_vars(self, monkeypatch):
-        from env_config import activate_lem_connection, ACTIVE_LEM_CONNECTION
+        from env_config import ACTIVE_LEM_CONNECTION, activate_lem_connection
 
         monkeypatch.setenv("LEM_CONNECTION_2_URL", "https://lem.example.com")
         monkeypatch.setenv("LEM_CONNECTION_2_TOKEN", "tok-2")
@@ -263,7 +263,7 @@ class TestLemConnectionHelpers:
         """Activating a bridge edge instance overrides EDGE_MANAGER_URL/TOKEN, so
         ACTIVE_LEM_CONNECTION must be cleared to reflect that the LEM creds now
         belong to the edge instance, not a standalone connection."""
-        from env_config import activate_edge_instance, ACTIVE_LEM_CONNECTION
+        from env_config import ACTIVE_LEM_CONNECTION, activate_edge_instance
 
         monkeypatch.setenv("EDGE_INSTANCE_5_TYPE", "lem")
         monkeypatch.setenv("EDGE_INSTANCE_5_URL", "https://bridge-lem.example.com")
@@ -290,7 +290,7 @@ class TestLegacyLemMigration:
     """migrate_legacy_lem_settings: lift EDGE_MANAGER_URL/EDGE_API_TOKEN into LEM_CONNECTION_1."""
 
     def test_migration_creates_first_connection(self, monkeypatch):
-        from env_config import migrate_legacy_lem_settings, ACTIVE_LEM_CONNECTION
+        from env_config import ACTIVE_LEM_CONNECTION, migrate_legacy_lem_settings
 
         monkeypatch.setenv("EDGE_MANAGER_URL", "https://legacy-lem.example.com")
         monkeypatch.setenv("EDGE_API_TOKEN", "legacy-tok")
@@ -359,7 +359,7 @@ class TestLegacyLemMigration:
     ):
         """If EDGE_MANAGER_PROJECT_ID is set, the legacy creds belong to a bridge
         instance, not a standalone connection. Migrate them but don't auto-activate."""
-        from env_config import migrate_legacy_lem_settings, ACTIVE_LEM_CONNECTION
+        from env_config import ACTIVE_LEM_CONNECTION, migrate_legacy_lem_settings
 
         monkeypatch.setenv("EDGE_MANAGER_URL", "https://legacy.example.com")
         monkeypatch.setenv("EDGE_API_TOKEN", "tok")

--- a/tests/test_eval_fixes.py
+++ b/tests/test_eval_fixes.py
@@ -17,12 +17,12 @@ if str(SRC) not in sys.path:
 
 from mcp.shared.exceptions import McpError  # noqa: E402
 
-from utils.formatting import redact_secrets, REDACTED  # noqa: E402
-from tools.digitaltwins_tools import _to_save_hierarchy  # noqa: E402
 from tools.data_tools import (  # noqa: E402
     _device_measurement_name,
     _tag_data_source,
 )
+from tools.digitaltwins_tools import _to_save_hierarchy  # noqa: E402
+from utils.formatting import REDACTED, redact_secrets  # noqa: E402
 
 
 def _run(coro):

--- a/tests/test_influxdb_validation.py
+++ b/tests/test_influxdb_validation.py
@@ -16,12 +16,14 @@ import asyncio
 import json
 import os
 import sys
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from mcp.shared.exceptions import McpError
+
 from tools.data_tools import get_historical_data_from_influxdb_tool
 
 # ── helpers ────────────────────────────────────────────────────────────────

--- a/tests/test_integration_live.py
+++ b/tests/test_integration_live.py
@@ -206,8 +206,8 @@ def test_tag_crud_cycle(request_obj, crud_target):
     """create_devicehub_tag → update_devicehub_tag → delete_devicehub_tag."""
     from tools.devicehub_tools import (
         create_devicehub_tag,
-        update_devicehub_tag,
         delete_devicehub_tag,
+        update_devicehub_tag,
     )
 
     device_name = crud_target["device"].name

--- a/tests/test_lem_tools.py
+++ b/tests/test_lem_tools.py
@@ -15,14 +15,9 @@ from starlette.requests import Request
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from mcp.shared.exceptions import McpError  # noqa: E402
+from mcp.shared.exceptions import McpError
 
-from utils.auth import (  # noqa: E402
-    _default_admin_url,
-    get_lem_connection,
-    get_lem_project_id,
-)
-from tools.lem_tools import (  # noqa: E402
+from tools.lem_tools import (
     lem_bridge_get_le_info_tool,
     lem_bridge_list_devicehub_devices_tool,
     lem_dashboard_usage_tool,
@@ -40,7 +35,11 @@ from tools.lem_tools import (  # noqa: E402
     lem_list_device_versions_tool,
     lem_list_devices_tool,
 )
-
+from utils.auth import (
+    _default_admin_url,
+    get_lem_connection,
+    get_lem_project_id,
+)
 
 _LEM_HEADERS = {
     "EDGE_MANAGER_URL": "https://lem.example.com",

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -11,25 +11,26 @@ Parse with json.loads(result[0].text) and check "success" key.
 
 import asyncio
 import json
-import pytest
-from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, Mock, MagicMock, patch
-from starlette.requests import Request
-
-import sys
 import os
+import sys
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from starlette.requests import Request
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from mcp.shared.exceptions import McpError
-import tools.devicehub_tools as devicehub_tools
+
+from tools import devicehub_tools
 from tools.devicehub_tools import (
-    get_litmusedge_driver_list,
-    get_devicehub_devices,
     create_devicehub_device,
-    get_devicehub_device_tags,
     get_current_value_of_devicehub_tag,
     get_device_connection_status,
+    get_devicehub_device_tags,
+    get_devicehub_devices,
+    get_litmusedge_driver_list,
 )
 from tools.dm_tools import (
     get_litmusedge_friendly_name,
@@ -498,7 +499,7 @@ def test_connection_status_recent_data_is_connected(
     mock_list_registers.return_value = [_make_tag()]
     mock_influx_params.return_value = {}
 
-    recent = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    recent = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     client = MagicMock()
     client.query.side_effect = _influx_query_dispatch(
         _make_influx_result([{"time": recent, "value": 1.0}])
@@ -536,7 +537,7 @@ def test_connection_status_old_data_is_stale(
     mock_list_registers.return_value = [_make_tag()]
     mock_influx_params.return_value = {}
 
-    old = (datetime.now(timezone.utc) - timedelta(hours=2)).strftime(
+    old = (datetime.now(UTC) - timedelta(hours=2)).strftime(
         "%Y-%m-%dT%H:%M:%S.%fZ"
     )
     client = MagicMock()
@@ -578,7 +579,7 @@ def test_connection_status_checks_all_topics(
     ]
     mock_influx_params.return_value = {}
 
-    recent = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    recent = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
     def query_behavior(q):
         if "Flowing" in q:

--- a/tests/test_sdk_cli_tools.py
+++ b/tests/test_sdk_cli_tools.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from mcp.shared.exceptions import McpError
 
-import tools.sdk_cli_tools as sdk_cli_tools
+from tools import sdk_cli_tools
 from tools.sdk_cli_tools import (
     _build_cli_env,
     _is_read_function,


### PR DESCRIPTION
CI ran an unpinned 'uvx ruff check .', so ruff 0.16's changed default rule set failed lint on an unrelated dependency bump. 0.16 is not a superset of the old default: it added ~15 opinionated families and dropped pycodestyle E4, which silently retired the '# noqa: E402' directives documenting the deliberate sys.path ordering in the tests.

The rule set is now named in pyproject.toml instead of inherited from whatever ruff is newest, and the version comes from the lint group in uv.lock so upgrades arrive as reviewable dependabot PRs.

Adopts the mechanically enforceable families 0.16 surfaced (I, UP, RUF, FURB, PLR0402) and fixes all 101 findings. The judgment-heavy families it also enables are left off pending a per-site review, mostly 107 blind 'except Exception' handlers.