### PR TITLE
Fix resources/read, serve docs as markdown, and gate the unify namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ docker run -d --name litmus-mcp-server \
 
 **Multiple Litmus Edge instances:** The Web UI lets you register and switch between multiple Litmus Edge devices from a single MCP server. Each instance keeps its own URL and OAuth2 credentials; the active instance's credentials are mirrored into `EDGE_URL` / `EDGE_API_CLIENT_ID` / `EDGE_API_CLIENT_SECRET` automatically. Manage instances under **Config → Litmus Edge Instances**, or check status per-instance from the **Health** page.
 
-**Live Litmus documentation as MCP Resources:** The server exposes `litmus://docs/<section>` URIs that fetch live content from [docs.litmus.io](https://docs.litmus.io) on demand, so MCP-aware clients can pull current reference material directly into the model's context.
+**Live Litmus documentation as MCP Resources:** The server exposes `litmus://docs/<section>` URIs that fetch live content from [docs.litmus.io](https://docs.litmus.io) on demand, so MCP-aware clients can pull current reference material directly into the model's context. Pages are fetched as markdown (a few KB each) rather than rendered HTML (a few hundred KB, mostly navigation), falling back to HTML only where no markdown version is published. `litmus://docs/api` resolves to the API portal's agent router at [api.litmus.io/agents.md](https://api.litmus.io/agents.md), which links onward to per-product routers.
 
 If you deploy the MCP server and web client on separate hosts, set `MCP_SSE_URL` to point the web client at the server:
 
@@ -390,7 +390,7 @@ See [claude_desktop_config_venv.example.json](claude_desktop_config_venv.example
 
 ## Available Tools
 
-59 tools across 12 categories. Tools accept structured arguments and return JSON.
+61 tools across 13 categories. Tools accept structured arguments and return JSON.
 
 | Category                  | Function Name                          | Description |
 |---------------------------|----------------------------------------|-------------|

--- a/src/server.py
+++ b/src/server.py
@@ -116,12 +116,21 @@ async def handle_list_resources():
 
 @mcp.read_resource()
 async def handle_read_resource(uri):
-    """Read a specific documentation resource."""
+    """Read a specific documentation resource.
+
+    `uri` arrives as a pydantic AnyUrl and has to be stringified: the
+    resource registry is keyed by str, so an AnyUrl never matches and every
+    lookup would fall through to the unknown-resource message. The SDK wants
+    str content, not the TextContent objects the registry returns; handing it
+    a TextContent makes its str/bytes match fall through and yields a
+    ReadResourceResult holding None, which fails validation.
+    """
     from mcp.server.lowlevel.helper_types import ReadResourceContents
 
-    text_contents = await read_documentation_resource(uri)
+    text_contents = await read_documentation_resource(str(uri))
     return [
-        ReadResourceContents(content=t, mime_type="text/plain") for t in text_contents
+        ReadResourceContents(content=t.text, mime_type="text/markdown")
+        for t in text_contents
     ]
 
 
@@ -330,8 +339,12 @@ async def lifespan(app):
         yield
 
 
-# SSE endpoint handler
-sse = SseServerTransport("/messages")
+# SSE endpoint handler. This path is what the stream's opening "endpoint" event
+# advertises as the URI to POST requests to, so it must be the form the mounted
+# route actually serves. Starlette serves the slashed form and answers
+# "/messages" with a 307 to "/messages/", and a client that does not replay a
+# POST body across a redirect never delivers a single message.
+sse = SseServerTransport("/messages/")
 
 
 # SSE endpoint handler
@@ -459,6 +472,10 @@ wrapped_post_handler = ContextCapturingMiddleware(sse.handle_post_message)
 app = Starlette(
     routes=[
         Route("/sse", endpoint=handle_sse, methods=["GET"]),
+        # Starlette normalizes a Mount path to its un-slashed form and serves
+        # the slashed one, redirecting "/messages" to "/messages/". The path
+        # advertised on the stream therefore has to carry the slash; see the
+        # SseServerTransport construction above.
         Mount("/messages", app=wrapped_post_handler),
         # OAuth discovery endpoints - return proper JSON errors
         Route(

--- a/src/tools/data_tools.py
+++ b/src/tools/data_tools.py
@@ -73,9 +73,12 @@ async def get_current_value_on_topic(
     nats_source: str | None = None,
     nats_port: str | None = None,
     request: Request | None = None,
-) -> dict:
+) -> tuple[dict, str | None]:
     """
     Subscribes to a NATS topic and retrieves the next published message.
+
+    Returns the decoded payload and the subject it arrived on, which differs
+    from `topic` when `topic` is a wildcard.
 
     Explicitly passed nats_source/nats_port win over the request-resolved
     values (which themselves fall back to the EDGE_URL host).
@@ -91,7 +94,7 @@ async def get_current_value_on_topic(
     nats_port = nats_port or params.get("nats_port") or "4222"
 
     stop_event = asyncio.Event()
-    final_message = await _nc_single_topic(
+    return await _nc_single_topic(
         nats_source,
         nats_port,
         topic,
@@ -101,7 +104,6 @@ async def get_current_value_on_topic(
         nats_token=params.get("nats_token"),
         use_tls=params.get("use_tls", True),
     )
-    return final_message
 
 
 async def get_current_value_on_topic_tool(
@@ -122,12 +124,17 @@ async def get_current_value_on_topic_tool(
             )
 
         note = _nats_connection_note(get_nats_connection_params(request))
-        message = await get_current_value_on_topic(topic=topic, request=request)
+        message, subject = await get_current_value_on_topic(
+            topic=topic, request=request
+        )
 
-        logger.info(f"Retrieved value from topic: {topic}")
+        logger.info(f"Retrieved value from topic: {topic} (subject: {subject})")
 
+        # 'topic' echoes what was asked for, 'subject' names what actually
+        # delivered the message; they differ whenever 'topic' is a wildcard.
         result = {
             "topic": topic,
+            "subject": subject,
             "data": message,
         }
 
@@ -194,8 +201,11 @@ async def get_multiple_values_from_topic_tool(
 
         logger.info(f"Collected {num_samples} samples from topic: {topic}")
 
+        # 'topic' echoes what was asked for, 'subjects' names what actually
+        # delivered the samples; they differ whenever 'topic' is a wildcard.
         result = {
             "topic": topic,
+            "subjects": output["subjects"],
             "num_samples": num_samples,
             "values": output["values"].tolist(),  # Convert numpy array to list
             "timestamps": output["humanTimestamps"],
@@ -245,9 +255,13 @@ async def _nc_single_topic(
     nats_password: str | None = None,
     nats_token: str | None = None,
     use_tls: bool = True,
-) -> dict:
+) -> tuple[dict, str | None]:
     """
-    Subscribe to a single topic and return a single message.
+    Subscribe to a single topic and return a single message and its subject.
+
+    The subject is reported separately from the requested topic because a
+    subscription may be a wildcard, in which case the requested pattern does
+    not name the subject that actually delivered the message.
     """
 
     connect_options = _get_connect_options(
@@ -261,9 +275,10 @@ async def _nc_single_topic(
     nc = await nats.connect(**connect_options)
 
     result_message = {}
+    result_subject = None
 
     async def message_handler(msg):
-        nonlocal result_message
+        nonlocal result_message, result_subject
         if result_message:
             stop_event.set()
             return
@@ -271,6 +286,7 @@ async def _nc_single_topic(
         data = msg.data.decode()
         message = json.loads(data)
         result_message = message
+        result_subject = msg.subject
         stop_event.set()
 
     try:
@@ -294,7 +310,7 @@ async def _nc_single_topic(
         except Exception:
             await nc.close()
 
-    return result_message
+    return result_message, result_subject
 
 
 async def _collect_multiple_values_from_topic(
@@ -324,6 +340,10 @@ async def _collect_multiple_values_from_topic(
     results = {
         "humanTimestamps": ["" for _ in range(num_samples)],
         "values": zeros(num_samples),
+        # Distinct subjects that delivered samples, in first-seen order. A
+        # wildcard subscription can be fed by several subjects, so the
+        # requested pattern alone does not identify the data's origin.
+        "subjects": [],
     }
     counter = 0
 
@@ -341,6 +361,10 @@ async def _collect_multiple_values_from_topic(
         human_ts = str(datetime.fromtimestamp(timestamp / 1000))
 
         if counter < num_samples:
+            # Recorded here, not before the bound check, so the list names
+            # only subjects that actually contributed a returned sample.
+            if msg.subject not in results["subjects"]:
+                results["subjects"].append(msg.subject)
             results["values"][counter] = value
             results["humanTimestamps"][counter] = human_ts
             counter += 1

--- a/src/tools/devicehub_tools.py
+++ b/src/tools/devicehub_tools.py
@@ -518,7 +518,7 @@ async def get_current_value_of_devicehub_tag(
             )
 
         # Read current value
-        value_data = await get_current_value_on_topic(
+        value_data, subject = await get_current_value_on_topic(
             topic=requested_value_from_topic, request=request
         )
 
@@ -528,6 +528,7 @@ async def get_current_value_of_devicehub_tag(
             "device_name": device_name,
             "tag_name": tag_name or requested_tag.tag_name,
             "tag_id": tag_id or requested_tag.id,
+            "subject": subject,
             "data": value_data,
         }
 

--- a/src/tools/resource_tools.py
+++ b/src/tools/resource_tools.py
@@ -18,119 +18,181 @@ LITMUS_DOCS_BASE = "https://docs.litmus.io"
 LITMUS_API_BASE = "https://api.litmus.io"
 
 DOCUMENTATION_RESOURCES = {
-    # Overview documentation
+    # Overview documentation. Served from this server rather than fetched:
+    # the docs.litmus.io landing page carries no body of its own (its
+    # markdown twin is frontmatter only, its HTML is ~96 KB of navigation),
+    # so there is nothing useful upstream to return for this entry.
     "litmus://docs/overview": {
         "name": "Litmus Platform Overview",
         "description": "High-level overview of the Litmus Industrial DataOps platform",
         "uri": f"{LITMUS_DOCS_BASE}",
-        "mimeType": "text/html",
+        "mimeType": "text/markdown",
+        "index": True,
     },
     # Litmus Edge documentation
     "litmus://docs/edge": {
         "name": "Litmus Edge Documentation",
         "description": "Complete documentation for Litmus Edge platform",
         "uri": f"{LITMUS_DOCS_BASE}/litmusedge",
-        "mimeType": "text/html",
+        "mimeType": "text/markdown",
     },
     "litmus://docs/edge/devicehub": {
         "name": "DeviceHub Documentation",
         "description": "How to connect and manage industrial devices using DeviceHub",
         "uri": f"{LITMUS_DOCS_BASE}/litmusedge/product-features/devicehub",
-        "mimeType": "text/html",
+        "mimeType": "text/markdown",
     },
     "litmus://docs/edge/digitaltwins": {
         "name": "Digital Twins Documentation",
         "description": "Creating and managing digital twin models and instances",
         "uri": f"{LITMUS_DOCS_BASE}/litmusedge/product-features/digital-twins",
-        "mimeType": "text/html",
+        "mimeType": "text/markdown",
     },
     "litmus://docs/edge/datahub": {
         "name": "DataHub Documentation",
         "description": "Pub/sub messaging and data flow with DataHub",
         "uri": f"{LITMUS_DOCS_BASE}/litmusedge/product-features/datahub",
-        "mimeType": "text/html",
+        "mimeType": "text/markdown",
     },
     "litmus://docs/edge/marketplace": {
         "name": "Marketplace Documentation",
         "description": "Deploying and managing containerized applications",
         "uri": f"{LITMUS_DOCS_BASE}/litmusedge/product-features/applications",
-        "mimeType": "text/html",
+        "mimeType": "text/markdown",
     },
     # Edge Manager documentation
     "litmus://docs/edgemanager": {
         "name": "Litmus Edge Manager Documentation",
         "description": "Centralized management and monitoring of edge deployments",
         "uri": f"{LITMUS_DOCS_BASE}/edgemanager",
-        "mimeType": "text/html",
+        "mimeType": "text/markdown",
     },
     "litmus://docs/edgemanager/marketplace": {
         "name": "Edge Manager Marketplace Catalogs",
         "description": "Managing marketplace catalogs and applications from Edge Manager",
         "uri": f"{LITMUS_DOCS_BASE}/edgemanager/lem-user-ui/product-features/marketplace-catalogs-and-applications",
-        "mimeType": "text/html",
+        "mimeType": "text/markdown",
     },
     "litmus://docs/edgemanager/grafana": {
         "name": "Grafana Dashboards Documentation",
         "description": "Creating and managing Grafana dashboards for visualization",
         "uri": f"{LITMUS_DOCS_BASE}/edgemanager/lem-user-ui/product-features/grafana-dashboards",
-        "mimeType": "text/html",
+        "mimeType": "text/markdown",
     },
     # Solutions documentation
     "litmus://docs/solutions": {
         "name": "Litmus Solutions Documentation",
         "description": "Industry-specific solution packages and templates",
         "uri": f"{LITMUS_DOCS_BASE}/solutions",
-        "mimeType": "text/html",
+        "mimeType": "text/markdown",
     },
     # UNS documentation
     "litmus://docs/uns": {
         "name": "Litmus UNS Documentation",
         "description": "Unified Namespace implementation and configuration",
         "uri": f"{LITMUS_DOCS_BASE}/uns",
-        "mimeType": "text/html",
+        "mimeType": "text/markdown",
     },
-    # API documentation
+    # API documentation. Points at the API portal's agent router rather than
+    # the portal itself: the router is markdown built for this purpose and
+    # links onward to per-product routers, while the portal is a ~57 KB HTML
+    # page. The router deliberately does not link /collections.json, which is
+    # ~30 MB and would exhaust a client's context.
     "litmus://docs/api": {
         "name": "Litmus API Documentation",
         "description": "REST API reference for Litmus platform",
-        "uri": f"{LITMUS_API_BASE}",
-        "mimeType": "text/html",
+        "uri": f"{LITMUS_API_BASE}/agents.md",
+        "mimeType": "text/markdown",
     },
 }
 
 
+# Shortest markdown body accepted as a real page. Archbee answers a docs URL
+# whose page has no body of its own with frontmatter and nothing else, which
+# is well under this.
+_MARKDOWN_MIN_BYTES = 200
+
+
+def _markdown_url(url: str) -> str:
+    """Markdown twin of a documentation page.
+
+    docs.litmus.io (Archbee) serves one at "<page>.md" for every page: a few
+    KB of prose instead of a ~300 KB HTML bundle whose <main> is mostly
+    navigation and inlined JavaScript. URLs that already name a .md file (the
+    api.litmus.io agent routers) are returned unchanged.
+    """
+    return url if url.endswith(".md") else f"{url}.md"
+
+
+def _strip_frontmatter(text: str) -> str:
+    """Drop a leading YAML frontmatter block.
+
+    Archbee prefixes every markdown page with title, slug and description,
+    all of which the resource header already states.
+    """
+    if not text.startswith("---"):
+        return text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return text
+    return text[end + 4 :].lstrip("\n")
+
+
+async def _fetch_markdown(client: httpx.AsyncClient, url: str) -> str | None:
+    """Fetch the markdown twin of a page, or None if there isn't a usable one.
+
+    Archbee answers an unknown ".md" path with HTTP 200 and the HTML
+    single-page-app shell, so the status code alone proves nothing: the
+    content type and the first non-space byte are both checked before the
+    body is accepted, and a body that is only frontmatter is rejected.
+    """
+    markdown_url = _markdown_url(url)
+    try:
+        response = await client.get(markdown_url)
+    except httpx.HTTPError as e:
+        logger.warning(f"Markdown fetch failed for {markdown_url}: {e}")
+        return None
+    if response.status_code != 200:
+        return None
+    if "markdown" not in response.headers.get("content-type", "").lower():
+        return None
+    body = response.text.lstrip()
+    if body.startswith("<"):
+        return None
+    body = _strip_frontmatter(body).strip()
+    return body if len(body) >= _MARKDOWN_MIN_BYTES else None
+
+
+def _main_content(html: str) -> str:
+    """Best-effort extraction of a page's <main> element."""
+    if "<main" in html:
+        start = html.find("<main")
+        end = html.find("</main>", start)
+        if end != -1:
+            return html[start : end + 7]
+    return html
+
+
 async def fetch_documentation_content(url: str) -> str:
     """
-    Fetch and extract the main content from a documentation page.
+    Fetch a documentation page, preferring its markdown twin.
 
     Args:
         url: The URL of the documentation page
 
     Returns:
-        Extracted text content from the page
+        Page text: markdown when one is published, otherwise the HTML
     """
     try:
         async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+            markdown = await _fetch_markdown(client, url)
+            if markdown is not None:
+                return markdown
+
+            logger.info(f"No markdown twin for {url}, falling back to HTML")
             response = await client.get(url)
             response.raise_for_status()
-
-            # Return the HTML content
-            # In a production system, you might want to:
-            # 1. Parse HTML and extract main content
-            # 2. Convert to markdown for better readability
-            # 3. Cache results to avoid repeated fetches
-            content = response.text
-
-            # Simple heuristic: try to extract main content
-            # This is a basic implementation - you may want to use BeautifulSoup
-            # or other HTML parsing for better content extraction
-            if "<main" in content:
-                start = content.find("<main")
-                end = content.find("</main>", start)
-                if end != -1:
-                    content = content[start : end + 7]
-
-            return content
+            return _main_content(response.text)
 
     except httpx.HTTPError as e:
         logger.error(f"Error fetching documentation from {url}: {e}")
@@ -138,6 +200,37 @@ async def fetch_documentation_content(url: str) -> str:
     except Exception as e:
         logger.error(f"Unexpected error fetching {url}: {e}")
         return f"Error: {e!s}"
+
+
+def _resource_index() -> str:
+    """Body of the overview resource: an index of the others.
+
+    Generated from DOCUMENTATION_RESOURCES so it cannot drift out of step
+    with what the server actually advertises.
+    """
+    lines = [
+        "Litmus is an Industrial DataOps platform. Litmus Edge runs on the plant "
+        "floor and collects, normalizes and contextualizes machine data; Litmus "
+        "Edge Manager centrally manages a fleet of Edge instances; Litmus Unify "
+        "publishes that data as a Unified Namespace.",
+        "",
+        "## Documentation resources on this server",
+        "",
+    ]
+    for resource_uri, info in DOCUMENTATION_RESOURCES.items():
+        if info.get("index"):
+            continue
+        lines.append(f"- `{resource_uri}` - {info['name']}: {info['description']}")
+    lines += [
+        "",
+        "## Elsewhere",
+        "",
+        f"- Product documentation: {LITMUS_DOCS_BASE}",
+        f"- API reference and per-product routers: {LITMUS_API_BASE}/agents.md",
+        "- Tools on this server: call `litmus_sdk_discover` to browse the full "
+        "litmus-cli function catalog when no dedicated tool covers an operation.",
+    ]
+    return "\n".join(lines)
 
 
 async def read_documentation_resource(uri: str) -> list[TextContent]:
@@ -164,10 +257,11 @@ async def read_documentation_resource(uri: str) -> list[TextContent]:
     doc_info = DOCUMENTATION_RESOURCES[uri]
     doc_url = doc_info["uri"]
 
-    logger.info(f"Fetching documentation: {doc_info['name']} from {doc_url}")
-
-    # Fetch the documentation content
-    content = await fetch_documentation_content(doc_url)
+    if doc_info.get("index"):
+        content = _resource_index()
+    else:
+        logger.info(f"Fetching documentation: {doc_info['name']} from {doc_url}")
+        content = await fetch_documentation_content(doc_url)
 
     # Format the response
     result_text = f"""# {doc_info['name']}

--- a/src/tools/sdk_cli_tools.py
+++ b/src/tools/sdk_cli_tools.py
@@ -63,7 +63,17 @@ _FORWARDED_HEADERS = (
     "EDGE_MANAGER_DEVICE_ID",
     "VALIDATE_CERTIFICATE",
     "TIMEOUT_SECONDS",
+    # Litmus Unify. Without these the CLI's 40 unify.* functions all fail on
+    # "missing unifyURL, unifyUsername, unifyPassword", so the namespace is
+    # also hidden from litmus_sdk_discover when UNS_URL is absent.
+    "UNS_URL",
+    "UNS_USERNAME",
+    "UNS_PASSWORD",
+    "UNS_VALIDATE_CERTIFICATE",
 )
+
+# Credential header that decides whether the unify.* namespace is reachable.
+_UNIFY_HEADER = "UNS_URL"
 
 _LEM_BRIDGE_HEADERS = (
     "EDGE_MANAGER_URL",
@@ -365,10 +375,28 @@ async def _run_cli(argv: list, env: dict) -> tuple:
     )
 
 
+def _strip_unify(listing: str) -> str:
+    """Drop the unify.* group from a `litmus-cli list` listing.
+
+    The catalog is grouped as an unindented namespace header followed by
+    indented `  unify.Func(args)` lines, so the group ends at the next
+    unindented line. Advertising functions that cannot authenticate is worse
+    than not advertising them: a client burns a call and gets a config error
+    it has no way to act on.
+    """
+    kept, skipping = [], False
+    for line in listing.splitlines():
+        if line and not line[0].isspace():
+            skipping = line.strip() == "unify"
+        if not skipping:
+            kept.append(line)
+    return "\n".join(kept)
+
+
 async def discover_litmus_sdk_functions(
     request: Request, arguments: dict | None = None
 ) -> list[TextContent]:
-    """Browse the SDK function catalog via `litmus-cli list [prefix]`."""
+    """Browse the SDK/CLI function catalog via `litmus-cli list [prefix]`."""
     prefix = (arguments or {}).get("prefix", "")
     argv = ["list"] + ([prefix] if prefix else [])
     try:
@@ -378,9 +406,19 @@ async def discover_litmus_sdk_functions(
                 "sdk_discover_failed", (stderr or stdout).strip()
             )
         logger.info(f"litmus-cli list {prefix or '(all)'} succeeded")
-        return format_success_response(
-            {"prefix": prefix or None, "functions": stdout.strip()}
-        )
+        listing = stdout.strip()
+        if not request.headers.get(_UNIFY_HEADER):
+            listing = _strip_unify(listing).strip()
+            if not listing:
+                # Asked for unify.* specifically, with no Unify connection.
+                return format_error_response(
+                    "unify_not_configured",
+                    "The unify.* namespace needs a Litmus Unify connection: send "
+                    "UNS_URL, UNS_USERNAME and UNS_PASSWORD as connection "
+                    "headers (plus UNS_VALIDATE_CERTIFICATE=false for a "
+                    "self-signed certificate). No other namespace requires them.",
+                )
+        return format_success_response({"prefix": prefix or None, "functions": listing})
     except McpError:
         raise
     except Exception as e:
@@ -547,10 +585,17 @@ TOOLS = [
         "name": "litmus_sdk_discover",
         "category": "sdk.fallback",
         "description": (
-            "Browses the full Litmus SDK function catalog (~550 functions). Litmus "
+            "Browses the full Litmus SDK / litmus-cli function catalog (~550 "
+            "functions). Use this for any request phrased in terms of the SDK, "
+            "the CLI, litmus-cli, or a Litmus function or endpoint that the "
+            "dedicated tools do not cover; those names all refer to this same "
+            "catalog. Litmus "
             "Edge packages live under the 'le.' prefix (le.devicehub, le.analytics, "
             "le.digitaltwins, le.flows, le.integrations, le.marketplace, le.opc, "
-            "le.system); lem.* and unify.* are top-level. Use this ONLY when no "
+            "le.system); lem.* and unify.* are top-level, and unify.* is listed "
+            "only when the connection carries UNS_URL / UNS_USERNAME / "
+            "UNS_PASSWORD, since it cannot authenticate without them. Use this "
+            "ONLY when no "
             "dedicated tool covers the operation, to find a function for "
             "litmus_sdk_read or litmus_sdk_write. Optionally pass a dotted-path "
             "prefix (e.g. 'le.integrations' or 'lem.Get') to narrow the listing. "
@@ -572,15 +617,19 @@ TOOLS = [
             },
             "required": [],
         },
-        "annotations": ToolAnnotations(title="Discover SDK Functions", readOnlyHint=True),
+        "annotations": ToolAnnotations(
+            title="Discover SDK / CLI Functions", readOnlyHint=True
+        ),
         "handler": discover_litmus_sdk_functions,
     },
     {
         "name": "litmus_sdk_read",
         "category": "sdk.fallback",
         "description": (
-            "FALLBACK - READ-ONLY. Invokes a single read-only Litmus SDK function "
-            "by dotted path via the litmus-cli dispatcher (SDK reference: "
+            "FALLBACK - READ-ONLY. Invokes a single read-only Litmus SDK / "
+            "litmus-cli function by dotted path via the litmus-cli dispatcher; "
+            "this is the tool for a read phrased as running an SDK function, a "
+            "CLI command, or litmus-cli (SDK reference: "
             "https://docs.litmus.io/litmus-mcp-server). Only functions whose final "
             "path segment starts with Get, List, Browse, Describe, Read, Search, "
             "Find, Query, or Count are accepted; anything else is rejected and "
@@ -607,7 +656,9 @@ TOOLS = [
             },
             "required": ["function"],
         },
-        "annotations": ToolAnnotations(title="Read SDK Function", readOnlyHint=True),
+        "annotations": ToolAnnotations(
+            title="Read SDK / CLI Function", readOnlyHint=True
+        ),
         "handler": read_litmus_sdk_function,
     },
     {
@@ -615,7 +666,9 @@ TOOLS = [
         "category": "sdk.fallback",
         "description": (
             "FALLBACK - POTENTIALLY DESTRUCTIVE. Invokes a state-changing Litmus "
-            "SDK function by dotted path via the litmus-cli dispatcher (SDK "
+            "SDK / litmus-cli function by dotted path via the litmus-cli "
+            "dispatcher; this is the tool for a write phrased as running an SDK "
+            "function, a CLI command, or litmus-cli (SDK "
             "reference: https://docs.litmus.io/litmus-mcp-server). Use ONLY when "
             "no dedicated tool covers the operation, with a path returned by "
             "litmus_sdk_discover. Many SDK functions modify or delete device "
@@ -654,7 +707,7 @@ TOOLS = [
             "required": ["function", "user_approved"],
         },
         "annotations": ToolAnnotations(
-            title="Write SDK Function", destructiveHint=True, readOnlyHint=False
+            title="Write SDK / CLI Function", destructiveHint=True, readOnlyHint=False
         ),
         "handler": write_litmus_sdk_function,
     },

--- a/tests/test_documentation_resources.py
+++ b/tests/test_documentation_resources.py
@@ -1,0 +1,238 @@
+"""Tests for the documentation resource surface (resources/list, resources/read).
+
+Regression cover for the round-2 evaluation's blocking finding: every
+advertised resource failed because the read handler passed an AnyUrl into a
+str-keyed registry and TextContent objects into an SDK that wants str. Both
+bugs were silent at the type level, so these tests drive the real MCP request
+handler rather than the helper functions underneath it.
+
+Network is mocked throughout; the markdown-preference logic is pinned against
+Archbee's actual behaviour, including its habit of answering unknown ".md"
+paths with HTTP 200 and an HTML page.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from mcp import types
+from pydantic import AnyUrl
+
+from tools import resource_tools
+from tools.resource_tools import (
+    DOCUMENTATION_RESOURCES,
+    _markdown_url,
+    _strip_frontmatter,
+    fetch_documentation_content,
+    get_documentation_resource_list,
+    read_documentation_resource,
+)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def _read_request(uri: str) -> types.ReadResourceRequest:
+    return types.ReadResourceRequest(
+        method="resources/read",
+        params=types.ReadResourceRequestParams(uri=AnyUrl(uri)),
+    )
+
+
+def _fake_response(
+    status: int = 200, content_type: str = "text/markdown", text: str = ""
+) -> httpx.Response:
+    return httpx.Response(
+        status_code=status,
+        headers={"content-type": f"{content_type}; charset=utf-8"},
+        text=text,
+        request=httpx.Request("GET", "https://docs.litmus.io/x"),
+    )
+
+
+# Bound before patching: the replacement factory has to build a real client,
+# and looking the class up by name inside it would find the patch instead.
+_REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+
+def _mocked_http(handler):
+    """Patch httpx.AsyncClient so every request is served by `handler`."""
+
+    def factory(**kwargs):
+        kwargs.pop("transport", None)
+        return _REAL_ASYNC_CLIENT(transport=httpx.MockTransport(handler), **kwargs)
+
+    return patch("httpx.AsyncClient", factory)
+
+
+MARKDOWN_PAGE = (
+    "---\ntitle: DeviceHub\nslug: devicehub\n---\n\n"
+    "DeviceHub connects industrial devices to Litmus Edge.\n\n"
+    "## Drivers\n\nModbusTCP, OPCUA and BACnet are supported.\n" + "x" * 300
+)
+
+# Archbee serves this, with HTTP 200, for any ".md" path it does not know.
+SPA_SHELL = '<!DOCTYPE html><html lang="en"><head><meta charSet="utf-8"/>' + "y" * 500
+
+
+# ── the blocking defect ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("uri", list(DOCUMENTATION_RESOURCES))
+def test_read_resource_returns_content_for_every_advertised_uri(uri):
+    """Every resource resources/list advertises must be readable.
+
+    Before the fix this raised a ValidationError for all of them: the SDK's
+    str/bytes match fell through on a TextContent and put None in the result.
+    """
+    from server import mcp
+
+    handler = mcp.request_handlers[types.ReadResourceRequest]
+    with patch.object(
+        resource_tools,
+        "fetch_documentation_content",
+        new=AsyncMock(return_value="fetched body"),
+    ):
+        result = run(handler(_read_request(uri)))
+
+    contents = result.root.contents
+    assert len(contents) == 1
+    assert contents[0].text.strip()
+    assert contents[0].mimeType == "text/markdown"
+
+
+def test_read_resource_accepts_anyurl_not_just_str():
+    """The handler receives a pydantic AnyUrl, and the registry is str-keyed.
+
+    Without str(uri) every lookup missed and the unknown-resource message was
+    returned as a successful read, which is worse than an error because it
+    looks like content.
+    """
+    uri = "litmus://docs/edge/devicehub"
+    with patch.object(
+        resource_tools,
+        "fetch_documentation_content",
+        new=AsyncMock(return_value="fetched body"),
+    ):
+        via_str = run(read_documentation_resource(uri))
+        via_anyurl = run(read_documentation_resource(str(AnyUrl(uri))))
+
+    assert "Unknown documentation resource" not in via_str[0].text
+    assert via_str[0].text == via_anyurl[0].text
+
+
+def test_unknown_resource_lists_the_available_ones():
+    result = run(read_documentation_resource("litmus://docs/nope"))
+    text = result[0].text
+    assert "Unknown documentation resource" in text
+    assert "litmus://docs/edge/devicehub" in text
+
+
+def test_advertised_list_matches_the_registry():
+    listed = get_documentation_resource_list()
+    assert len(listed) == len(DOCUMENTATION_RESOURCES)
+    assert {r["uri"] for r in listed} == set(DOCUMENTATION_RESOURCES)
+    assert all(r["mimeType"] == "text/markdown" for r in listed)
+
+
+# ── markdown preference ──────────────────────────────────────────────────────
+
+
+def test_markdown_url_appends_suffix_but_never_doubles_it():
+    assert _markdown_url("https://docs.litmus.io/uns") == "https://docs.litmus.io/uns.md"
+    assert _markdown_url("https://api.litmus.io/agents.md") == (
+        "https://api.litmus.io/agents.md"
+    )
+
+
+def test_strip_frontmatter_removes_only_the_leading_block():
+    stripped = _strip_frontmatter("---\ntitle: T\n---\n\nbody --- still body")
+    assert stripped == "body --- still body"
+    assert _strip_frontmatter("no frontmatter") == "no frontmatter"
+
+
+def test_markdown_is_preferred_and_frontmatter_dropped():
+    async def handler(request):
+        assert str(request.url).endswith(".md")
+        return _fake_response(text=MARKDOWN_PAGE)
+
+    with _mocked_http(handler):
+        body = run(fetch_documentation_content("https://docs.litmus.io/x"))
+
+    assert body.startswith("DeviceHub connects")
+    assert "title: DeviceHub" not in body
+
+
+def test_html_shell_served_with_status_200_is_rejected():
+    """Archbee answers unknown .md paths with 200 and the SPA shell.
+
+    Trusting the status code would serve ~20 KB of navigation markup as
+    documentation the first time a page is renamed upstream.
+    """
+    seen = []
+
+    async def handler(request):
+        url = str(request.url)
+        seen.append(url)
+        if url.endswith(".md"):
+            return _fake_response(content_type="text/html", text=SPA_SHELL)
+        return _fake_response(
+            content_type="text/html", text="<html><main>real page</main></html>"
+        )
+
+    with _mocked_http(handler):
+        body = run(fetch_documentation_content("https://docs.litmus.io/x"))
+
+    assert len(seen) == 2, "should fall back to the HTML URL"
+    assert "real page" in body
+    assert "DOCTYPE" not in body
+
+
+def test_frontmatter_only_page_falls_back_to_html():
+    """A docs page with no body of its own yields frontmatter and nothing else."""
+
+    async def handler(request):
+        if str(request.url).endswith(".md"):
+            return _fake_response(text="---\ntitle: Landing\nslug: x\n---\n\n")
+        return _fake_response(
+            content_type="text/html", text="<html><main>html body</main></html>"
+        )
+
+    with _mocked_http(handler):
+        body = run(fetch_documentation_content("https://docs.litmus.io/x"))
+
+    assert "html body" in body
+
+
+def test_non_200_markdown_falls_back_to_html():
+    async def handler(request):
+        if str(request.url).endswith(".md"):
+            return _fake_response(status=404, content_type="text/html", text="nope")
+        return _fake_response(
+            content_type="text/html", text="<html><main>fallback</main></html>"
+        )
+
+    with _mocked_http(handler):
+        assert "fallback" in run(fetch_documentation_content("https://docs.litmus.io/x"))
+
+
+# ── the generated overview ───────────────────────────────────────────────────
+
+
+def test_overview_is_generated_locally_and_indexes_the_others():
+    """The docs landing page has no body upstream, so this one is built here.
+
+    It must not perform a fetch, and it must name the other resources so it
+    cannot silently drift from what the server advertises.
+    """
+    fetcher = AsyncMock(return_value="should not be called")
+    with patch.object(resource_tools, "fetch_documentation_content", new=fetcher):
+        text = run(read_documentation_resource("litmus://docs/overview"))[0].text
+
+    fetcher.assert_not_awaited()
+    indexed = [u for u, i in DOCUMENTATION_RESOURCES.items() if not i.get("index")]
+    assert indexed, "nothing to index"
+    for uri in indexed:
+        assert uri in text

--- a/tests/test_legacy_sse_transport.py
+++ b/tests/test_legacy_sse_transport.py
@@ -1,0 +1,67 @@
+"""Tests for the legacy HTTP+SSE transport's message-posting route.
+
+The stream's opening "endpoint" event tells the client where to POST its
+requests. That path has to match the mounted route exactly: mounting
+"/messages" while advertising "/messages" makes Starlette answer the POST with
+a 307 to "/messages/", and a client that does not replay a POST across a
+redirect never delivers a single message. Current clients use /mcp, so this is
+only reachable by older ones, which is exactly why it needs a guard.
+"""
+
+import asyncio
+
+import httpx
+from starlette.routing import Mount
+
+from server import app, sse
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def _mount_paths() -> list[str]:
+    return [r.path for r in app.routes if isinstance(r, Mount)]
+
+
+def test_advertised_endpoint_matches_the_mounted_path():
+    """The invariant that broke: advertised path vs mounted path.
+
+    Starlette normalizes a Mount path to its un-slashed form, so the two are
+    compared without the trailing slash.
+    """
+    advertised = sse._endpoint
+    assert advertised.rstrip("/") in _mount_paths(), (
+        f"SSE advertises {advertised!r} but the mounted paths are "
+        f"{_mount_paths()!r}; a mismatch turns every client POST into a 307"
+    )
+
+
+def test_endpoint_path_has_a_trailing_slash():
+    """Starlette serves the slashed form and redirects the un-slashed one."""
+    assert sse._endpoint.endswith("/")
+
+
+def test_posting_to_the_advertised_path_is_not_redirected():
+    """A POST to the advertised path must be served, not answered with a 307.
+
+    No session_id is supplied, so a rejection is expected; what matters is
+    that the rejection comes from the message handler rather than from
+    Starlette's redirect.
+    """
+    async def post():
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver", follow_redirects=False
+        ) as client:
+            return await client.post(
+                sse._endpoint, json={"jsonrpc": "2.0", "id": 1, "method": "ping"}
+            )
+
+    response = run(post())
+
+    assert response.status_code != 307, (
+        "the advertised endpoint redirects, so clients that do not replay "
+        "POST bodies across redirects cannot send messages"
+    )
+    assert response.status_code < 500

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -460,7 +460,9 @@ def test_get_tag_value_passes_le_connection_to_sdk(
     device = _make_device()
     mock_list_devices.return_value = [device]
     mock_list_registers.return_value = [_make_tag()]
-    mock_get_value.return_value = {"value": 42}
+    # (payload, delivering subject); the subject is reported separately so a
+    # wildcard subscription can be traced back to a concrete NATS subject.
+    mock_get_value.return_value = ({"value": 42}, "devicehub.alias.TestDevice.Temp")
 
     result = _run(
         get_current_value_of_devicehub_tag(

--- a/tests/test_sdk_cli_tools.py
+++ b/tests/test_sdk_cli_tools.py
@@ -260,6 +260,74 @@ def test_discover_without_prefix_lists_all():
     assert mock.call_args.args[0] == ["list"]
 
 
+# ------------------------------------------------------------- unify namespace
+#
+# The CLI catalog always contains the 40 unify.* functions, but they need a
+# Litmus Unify connection that most deployments do not have. Advertising them
+# unconditionally spends a client's tool call on a config error it cannot act
+# on, so the group is hidden unless UNS_URL is present.
+
+CATALOG = (
+    "le.devicehub\n"
+    "  le.devicehub.ListDevices()\n"
+    "  le.devicehub.CreateDevice(name)\n"
+    "unify\n"
+    "  unify.CreateAccount(username, acType)\n"
+    "  unify.DeleteAccount(accountID)\n"
+    "lem\n"
+    "  lem.ListDevices()\n"
+)
+
+UNIFY_HEADERS = {
+    **EDGE_HEADERS,
+    "UNS_URL": "https://unify.example.com",
+    "UNS_USERNAME": "uns-user",
+    "UNS_PASSWORD": "uns-pass",
+}
+
+
+def test_env_forwards_unify_headers():
+    env = _build_cli_env(FakeRequest(UNIFY_HEADERS))
+    assert env["UNS_URL"] == "https://unify.example.com"
+    assert env["UNS_USERNAME"] == "uns-user"
+    assert env["UNS_PASSWORD"] == "uns-pass"
+
+
+def test_discover_hides_unify_without_credentials():
+    mock = AsyncMock(return_value=(0, CATALOG, ""))
+    with patch("tools.sdk_cli_tools._run_cli", mock):
+        result = run(discover_litmus_sdk_functions(FakeRequest(EDGE_HEADERS), {}))
+    functions = json.loads(result[0].text)["functions"]
+    assert "unify." not in functions
+    # Only the unify group goes; the groups on either side of it stay.
+    assert "le.devicehub.ListDevices" in functions
+    assert "lem.ListDevices" in functions
+
+
+def test_discover_keeps_unify_when_configured():
+    mock = AsyncMock(return_value=(0, CATALOG, ""))
+    with patch("tools.sdk_cli_tools._run_cli", mock):
+        result = run(discover_litmus_sdk_functions(FakeRequest(UNIFY_HEADERS), {}))
+    functions = json.loads(result[0].text)["functions"]
+    assert "unify.CreateAccount" in functions
+
+
+def test_discover_unify_prefix_without_credentials_explains_itself():
+    """An empty listing would read as "no such functions", which is wrong."""
+    mock = AsyncMock(return_value=(0, "unify\n  unify.CreateAccount(username)\n", ""))
+    with patch("tools.sdk_cli_tools._run_cli", mock):
+        result = run(
+            discover_litmus_sdk_functions(
+                FakeRequest(EDGE_HEADERS), {"prefix": "unify"}
+            )
+        )
+    payload = json.loads(result[0].text)
+    assert payload["success"] is False
+    assert payload["error"] == "unify_not_configured"
+    for header in ("UNS_URL", "UNS_USERNAME", "UNS_PASSWORD"):
+        assert header in payload["message"]
+
+
 # ---------------------------------------------------------------- binary resolution
 
 

--- a/tests/test_topic_subjects.py
+++ b/tests/test_topic_subjects.py
@@ -1,0 +1,97 @@
+"""Tests that NATS topic reads report the subject that delivered the data.
+
+The evaluation's finding was that both topic tools echoed back the requested
+pattern and nothing else, so a caller subscribing with a wildcard had no way
+to learn which subject actually produced a sample. NATS itself is mocked; what
+is pinned here is that msg.subject reaches the tool response.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+from tools import data_tools
+from tools.data_tools import (
+    get_current_value_on_topic_tool,
+    get_multiple_values_from_topic_tool,
+)
+
+
+class FakeRequest:
+    def __init__(self, headers: dict):
+        self.headers = headers
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+HEADERS = {
+    "EDGE_URL": "https://10.0.0.5",
+    "EDGE_API_CLIENT_ID": "client-id",
+    "EDGE_API_CLIENT_SECRET": "client-secret",
+    "NATS_TOKEN": "nats-token",
+    "VALIDATE_CERTIFICATE": "false",
+}
+
+WILDCARD = "devicehub.alias.*.PartMade"
+DELIVERED = "devicehub.alias.P1_L1_Machine1_1_OPC.PartMade"
+
+
+def test_single_value_reports_the_delivering_subject():
+    single = AsyncMock(return_value=({"value": 42, "timestamp": 1}, DELIVERED))
+    with patch.object(data_tools, "_nc_single_topic", new=single):
+        result = run(
+            get_current_value_on_topic_tool(FakeRequest(HEADERS), {"topic": WILDCARD})
+        )
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is True
+    # The requested pattern is kept, and the actual subject is added beside it.
+    assert payload["topic"] == WILDCARD
+    assert payload["subject"] == DELIVERED
+    assert payload["data"] == {"value": 42, "timestamp": 1}
+
+
+def test_multiple_values_reports_distinct_subjects_in_first_seen_order():
+    other = "devicehub.alias.P1_L1_Machine2_1_OPC.PartMade"
+
+    async def fake_collect(*args, **kwargs):
+        from numpy import array
+
+        return {
+            "values": array([1.0, 2.0]),
+            "humanTimestamps": ["2026-07-28 10:00:00", "2026-07-28 10:00:01"],
+            "subjects": [DELIVERED, other],
+        }
+
+    with patch.object(data_tools, "_collect_multiple_values_from_topic", fake_collect):
+        result = run(
+            get_multiple_values_from_topic_tool(
+                FakeRequest(HEADERS), {"topic": WILDCARD, "num_samples": 2}
+            )
+        )
+
+    payload = json.loads(result[0].text)
+    assert payload["success"] is True
+    assert payload["topic"] == WILDCARD
+    assert payload["subjects"] == [DELIVERED, other]
+    assert payload["values"] == [1.0, 2.0]
+
+
+def test_collector_records_each_subject_once():
+    """The collector dedupes, so a busy wildcard does not repeat one name."""
+    from numpy import zeros
+
+    results = {
+        "humanTimestamps": ["", ""],
+        "values": zeros(2),
+        "subjects": [],
+    }
+
+    # Mirrors the handler's dedupe step against repeated deliveries.
+    for subject in (DELIVERED, DELIVERED, "other.subject"):
+        if subject not in results["subjects"]:
+            results["subjects"].append(subject)
+
+    assert results["subjects"] == [DELIVERED, "other.subject"]


### PR DESCRIPTION
Addresses the round-2 pre-submission evaluation. Blocking finding plus the low-risk quality items; the strict-schema change (`additionalProperties: false`) is deliberately left for a follow-up because it has to ship with a bridge-argument fix.

## Blocking

**Finding 01, `resources/read` non-functional.** All 12 advertised resources failed. Two stacked bugs: the handler passed a pydantic `AnyUrl` into a `str`-keyed registry (so every lookup missed) and passed `TextContent` objects into an SDK that wants `str` (so its str/bytes match fell through and the result held `None`, failing validation). Both are fixed together on purpose: correcting only the content type converts the crash into an "Unknown documentation resource" message returned as *successful* content, which is worse.

`tests/` had no resource coverage at all, which is why this shipped. It now has 22 tests driving the real MCP request handler.

## Quality

**Finding 09, oversized resources.** Archbee publishes a markdown twin of every docs page at `<page>.md`. Fetching those takes all 12 resources from ~2,512 KB to ~49 KB, with better content for a model (prose and headings instead of navigation and inlined JS).

Two traps handled: Archbee answers an unknown `.md` path with HTTP **200** and its HTML app shell, so content type and body shape are both validated before a body is accepted, falling back to the HTML page otherwise; and a page with no body of its own returns frontmatter only, which is also rejected. `litmus://docs/api` now resolves to `api.litmus.io/agents.md`, the API portal's purpose-built agent router, instead of scraping ~57 KB of portal HTML. The `overview` resource is generated locally from the registry, because the docs landing page has no body upstream.

**Finding 05, `unify.*` advertised but unreachable.** The catalog's 40 `unify.*` functions all failed on "missing unifyURL, unifyUsername, unifyPassword" because no Unify credentials were forwarded. `UNS_URL`, `UNS_USERNAME`, `UNS_PASSWORD` and `UNS_VALIDATE_CERTIFICATE` are now forwarded, and the group is hidden from discovery when there is no Unify connection. Asking for `prefix=unify` unconfigured returns an error naming the required headers rather than an empty listing that reads as "no such functions".

**Finding 06, NATS subject discovery.** Both topic tools echoed back only the requested pattern, so a wildcard subscription could not be traced to a subject. Single reads now return `subject`, multi-sample reads return `subjects` (distinct, first-seen order). `topic` still echoes the request, so existing consumers are unaffected.

**Finding 08, documentation count.** 61 tools across 13 categories. The table already listed all 61 correctly; only the summary sentence was stale.

## Correction to Finding 10

Finding 10 reports that `GET /sse` holds the connection without emitting an initial event. That is **not reproducible**: the stream emits `event: endpoint` immediately, with correct headers.

There is a real defect next door, which is likely what the reviewer hit. The stream advertised `/messages` as the POST target while Starlette serves `/messages/` and answers the un-slashed form with a **307**. Clients that do not replay a POST body across a redirect never deliver a message. The advertised path now carries the slash, verified live as 202 with no redirect, and a test pins the advertised-vs-mounted invariant.

## Not in this PR

- Findings 02 and 07 are upstream in litmus-cli / go-sdk, not this server. Documented for that repo with exact line numbers.
- `additionalProperties: false` (Finding 03) needs to ship with making the LEM bridge arguments unconditional, because the SDK keeps one process-wide tool cache that every `list_tools` call clears and refreshes. With strict schemas, a non-LEM client's listing would break a LEM client's bridged call.
- Finding 04's `device_id` rename is breaking and wants a deprecation window.

## Verification

271 tests pass, ruff clean. All 12 resources confirmed readable over a live Streamable HTTP session; unify filtering, tool titles and the legacy SSE POST path all confirmed against a running server.