### PR TITLE
Reject unknown tool arguments, reach Unify from the extension, bump to 1.4.0

### DIFF
--- a/desktop-extension/README.md
+++ b/desktop-extension/README.md
@@ -16,6 +16,8 @@ you configure.
 - Litmus Edge OAuth2 API credentials (System > API Access on the device).
 - Optional: NATS and InfluxDB credentials for the real-time and
   historical data tools.
+- Optional: Litmus Unify URL, username and password, to reach the
+  `unify.*` SDK functions.
 
 ## Install
 
@@ -28,6 +30,13 @@ and start chatting.
 before connecting and names any that are missing. The NATS and InfluxDB
 fields are optional and only enable the real-time and historical data
 tools.
+
+The three Litmus Unify fields are optional too, but only work as a set:
+Unify authenticates separately from Litmus Edge, so filling in one and
+leaving the others empty is refused with a message naming what is still
+blank. Leave all three empty to skip Unify, in which case the server
+hides the `unify.*` functions from discovery rather than advertising
+functions that cannot authenticate.
 
 ## Transport security
 

--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -38,6 +38,9 @@
         "INFLUX_DB_NAME": "${user_config.influx_db_name}",
         "INFLUX_USERNAME": "${user_config.influx_username}",
         "INFLUX_PASSWORD": "${user_config.influx_password}",
+        "UNS_URL": "${user_config.uns_url}",
+        "UNS_USERNAME": "${user_config.uns_username}",
+        "UNS_PASSWORD": "${user_config.uns_password}",
         "VALIDATE_CERTIFICATE": "${user_config.validate_certificate}",
         "LITMUS_ALLOW_INSECURE_HTTP": "${user_config.allow_insecure_http}"
       }
@@ -112,6 +115,22 @@
       "type": "string",
       "title": "InfluxDB Password (optional)",
       "description": "DataHub password",
+      "sensitive": true
+    },
+    "uns_url": {
+      "type": "string",
+      "title": "Litmus Unify URL (optional)",
+      "description": "Base URL of a Litmus Unify instance, e.g. https://unify.example.com. Only needed to reach the unify.* SDK functions, which authenticate separately from Litmus Edge; leave empty to skip."
+    },
+    "uns_username": {
+      "type": "string",
+      "title": "Litmus Unify Username (optional)",
+      "description": "Required when Litmus Unify URL is set"
+    },
+    "uns_password": {
+      "type": "string",
+      "title": "Litmus Unify Password (optional)",
+      "description": "Required when Litmus Unify URL is set",
       "sensitive": true
     },
     "validate_certificate": {

--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "litmus-mcp",
   "display_name": "Litmus MCP",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Connect Claude to Litmus Edge industrial devices through your Litmus MCP Server.",
   "long_description": "Gives Claude access to your Litmus Edge deployment: browse DeviceHub devices and tags, read real-time and historical process data, manage Digital Twins, inspect system health, and reach the full Litmus SDK surface. This extension bridges Claude Desktop to a Litmus MCP Server you run on your own network (see https://github.com/litmusautomation/litmus-mcp-server); your credentials are stored in the operating system keychain and sent only to that server.",
   "author": {

--- a/desktop-extension/package.json
+++ b/desktop-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litmus-mcp-desktop-extension",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Claude Desktop extension bridging stdio to a Litmus MCP Server over streamable HTTP",
   "license": "MIT",
   "private": true,

--- a/desktop-extension/server/index.js
+++ b/desktop-extension/server/index.js
@@ -24,7 +24,27 @@ const HEADER_VARS = [
   "INFLUX_DB_NAME",
   "INFLUX_USERNAME",
   "INFLUX_PASSWORD",
+  // Litmus Unify authenticates separately from Litmus Edge. Without these the
+  // server hides the unify.* namespace from discovery rather than advertising
+  // functions that cannot authenticate.
+  "UNS_URL",
+  "UNS_USERNAME",
+  "UNS_PASSWORD",
   "VALIDATE_CERTIFICATE",
+];
+
+// Settings that are only meaningful together: configuring one without the
+// others yields a connection error from the SDK naming internal option names
+// rather than the fields the dialog shows, so they are checked here instead.
+const GROUPED_VARS = [
+  {
+    label: "Litmus Unify",
+    names: [
+      ["UNS_URL", "Litmus Unify URL"],
+      ["UNS_USERNAME", "Litmus Unify Username"],
+      ["UNS_PASSWORD", "Litmus Unify Password"],
+    ],
+  },
 ];
 
 // Fields the server cannot authenticate without, with the labels the
@@ -118,6 +138,21 @@ function buildLaunch(env) {
     const port = Number(value);
     if (!Number.isInteger(port) || port < 1 || port > 65535) {
       throw new ConfigError(`'${label}' must be a port number, got ${value}`);
+    }
+  }
+
+  for (const { label, names } of GROUPED_VARS) {
+    const set = names.filter(([name]) => readVar(env, name));
+    if (set.length && set.length !== names.length) {
+      const absent = names
+        .filter(([name]) => !readVar(env, name))
+        .map(([, fieldLabel]) => fieldLabel);
+      throw new ConfigError(
+        `${label} is partly configured: ${absent.join(", ")} ` +
+          `${absent.length > 1 ? "are" : "is"} still empty. Fill ${
+            absent.length > 1 ? "them" : "it"
+          } in, or clear the ${label} settings entirely to skip it.`
+      );
     }
   }
 

--- a/desktop-extension/test/launcher.test.js
+++ b/desktop-extension/test/launcher.test.js
@@ -168,3 +168,61 @@ test("the opt-in does not weaken anything over https", () => {
 test("resolves the bundled mcp-remote entry point", () => {
   assert.match(resolveMcpRemote(), /mcp-remote/);
 });
+
+// ── Litmus Unify ─────────────────────────────────────────────────────────────
+//
+// Unify authenticates separately from Litmus Edge, so its settings are optional
+// but only meaningful as a set. Without them the server hides the unify.*
+// namespace from discovery instead of advertising functions that cannot
+// authenticate, so forwarding all three is what makes the namespace reachable.
+
+const UNIFY = {
+  UNS_URL: "https://unify.example.com",
+  UNS_USERNAME: "uns-user",
+  UNS_PASSWORD: "uns-pass",
+};
+
+test("forwards the Unify headers when all three are set", () => {
+  const sent = headers(buildLaunch(env(UNIFY)).args);
+  assert.equal(sent.UNS_URL, "https://unify.example.com");
+  assert.equal(sent.UNS_USERNAME, "uns-user");
+  assert.equal(sent.UNS_PASSWORD, "uns-pass");
+});
+
+test("sends no Unify headers when none are set", () => {
+  const sent = headers(buildLaunch(env({})).args);
+  for (const name of Object.keys(UNIFY)) {
+    assert.equal(name in sent, false, `${name} should not be sent`);
+  }
+});
+
+test("a partly configured Unify names the empty fields", () => {
+  const err = configError(
+    () => buildLaunch(env({ UNS_URL: UNIFY.UNS_URL })),
+    "url only"
+  );
+  assert.match(err.message, /Litmus Unify is partly configured/);
+  assert.match(err.message, /Litmus Unify Username/);
+  assert.match(err.message, /Litmus Unify Password/);
+  // Clearing the group has to be offered as the alternative to filling it in.
+  assert.match(err.message, /clear the Litmus Unify settings entirely/);
+});
+
+test("a partly configured Unify is singular about one empty field", () => {
+  const err = configError(
+    () => buildLaunch(env({ UNS_URL: UNIFY.UNS_URL, UNS_USERNAME: "u" })),
+    "password missing"
+  );
+  assert.match(err.message, /Litmus Unify Password is still empty/);
+});
+
+test("unsubstituted Unify placeholders count as unset, not as partial config", () => {
+  const { args } = buildLaunch(
+    env({
+      UNS_URL: "${user_config.uns_url}",
+      UNS_USERNAME: "${user_config.uns_username}",
+      UNS_PASSWORD: "${user_config.uns_password}",
+    })
+  );
+  assert.equal("UNS_URL" in headers(args), false);
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litmus-mcp-server"
-version = "1.3.0"
+version = "1.4.0"
 description = "Litmus MCP Server"
 readme = "README.md"
 license = "MIT"

--- a/src/server.py
+++ b/src/server.py
@@ -167,12 +167,24 @@ _BRIDGE_ARG_PROPERTIES = {
             "bridge."
         ),
     },
+    # Declared, despite being superseded, because the schemas reject unknown
+    # arguments: an undeclared alias would be refused by validation before the
+    # dispatcher could accept it, which would break the very clients the alias
+    # exists for. Described as deprecated so a model picks lem_device_id.
+    "device_id": {
+        "type": "string",
+        "description": (
+            "DEPRECATED, use lem_device_id. Accepted only for compatibility "
+            "with clients configured before the rename; this is the LEM device "
+            "id, not the DeviceHub device id."
+        ),
+    },
 }
 
 # Superseded by lem_device_id. The old name meant the LEM device id here while
 # meaning the DeviceHub device id in tool payloads, which is the ambiguity the
 # rename removes. Still accepted so existing clients and saved prompts keep
-# working; it is not advertised in any schema.
+# working.
 _LEGACY_BRIDGE_DEVICE_ARG = "device_id"
 
 
@@ -188,6 +200,24 @@ def _with_bridge_args(schema: dict) -> dict:
     properties = schema.setdefault("properties", {})
     for key, prop in _BRIDGE_ARG_PROPERTIES.items():
         properties.setdefault(key, prop)
+    return schema
+
+
+def _strict(schema: dict) -> dict:
+    """Return a copy of the schema that rejects arguments it does not declare.
+
+    The SDK validates tool input against the advertised schema, so this turns a
+    misspelled argument into an error naming it instead of a silent fallback to
+    the default. That matters most where a default changes the data rather than
+    the page: asking for 7 days of history, typing the range argument wrong and
+    silently receiving 1 hour reads as an answer to the question asked.
+
+    Applied centrally rather than written into each tool's dict so it cannot be
+    forgotten on a new tool, and so no tool's schema is mutated in place.
+    """
+    schema = copy.deepcopy(schema)
+    schema.setdefault("type", "object")
+    schema["additionalProperties"] = False
     return schema
 
 
@@ -224,21 +254,25 @@ class _OverlayHeaders:
 async def handle_list_tools() -> list[Tool]:
     """Return all registered tools from the per-file TOOLS registries.
 
-    When the client is configured with LEM credentials (EDGE_MANAGER_URL
-    header present), edge-targeting tools additionally advertise optional
-    project_id/lem_device_id arguments for per-call LEM bridge routing.
+    Edge-targeting tools always advertise the optional project_id and
+    lem_device_id arguments for per-call LEM bridge routing, whether or not
+    this particular connection is configured for LEM. Advertising them only to
+    LEM-configured clients would be wrong now that the schemas reject unknown
+    arguments: the SDK keeps ONE process-wide tool cache which every
+    list_tools call clears and refreshes, so on a server with more than one
+    client the last listing decides what everybody is validated against. A
+    non-LEM client listing tools would strip the bridge arguments and a
+    LEM-configured client's next bridged call would be rejected as sending
+    something unexpected. The arguments are inert without LEM credentials, so
+    advertising them unconditionally costs nothing and removes the race.
     """
-    request = _resolve_request()
-    lem_configured = bool(
-        request is not None and request.headers.get("EDGE_MANAGER_URL")
-    )
     return [
         Tool(
             name=tool["name"],
             description=tool["description"],
-            inputSchema=(
+            inputSchema=_strict(
                 _with_bridge_args(tool["schema"])
-                if lem_configured and _is_bridgeable(tool)
+                if _is_bridgeable(tool)
                 else tool["schema"]
             ),
             annotations=tool.get("annotations"),

--- a/src/tools/sdk_cli_tools.py
+++ b/src/tools/sdk_cli_tools.py
@@ -108,7 +108,7 @@ def _get_isolated_dir() -> str:
 # same release the Dockerfile pins) instead of hard-failing the CLI-backed
 # tools.
 
-_FALLBACK_CLI_VERSION = "cli-v0.7.0"  # used only when Dockerfile is absent
+_FALLBACK_CLI_VERSION = "cli-v0.9.0"  # used only when Dockerfile is absent
 
 _BOOTSTRAP_BASE_DIR = Path.home() / ".cache" / "litmus-mcp-server" / "bin"
 

--- a/tests/test_bridge_routing.py
+++ b/tests/test_bridge_routing.py
@@ -67,8 +67,11 @@ def test_with_bridge_args_adds_optional_ids_without_mutating_original():
     injected = _with_bridge_args(original)
     assert "project_id" in injected["properties"]
     assert "lem_device_id" in injected["properties"]
-    # The old ambiguous name is accepted at call time but never advertised.
-    assert "device_id" not in injected["properties"]
+    # The deprecated alias has to be declared as well: schemas reject unknown
+    # arguments, so leaving it out would make validation refuse it before the
+    # dispatcher could accept it, breaking the clients it exists for.
+    assert "device_id" in injected["properties"]
+    assert "DEPRECATED" in injected["properties"]["device_id"]["description"]
     assert "project_id" not in original["properties"]
     # bridge ids are never required
     assert "project_id" not in injected.get("required", [])

--- a/tests/test_strict_schemas.py
+++ b/tests/test_strict_schemas.py
@@ -1,0 +1,190 @@
+"""Tests that tool schemas reject arguments they do not declare.
+
+The evaluation's finding was that a misspelled argument was accepted silently
+and the tool ran with defaults: `get_multiple_values_from_topic` asked for 2
+samples over 20s ran 10 over 30s and said so, with nothing contradicting the
+caller. The SDK validates input against the advertised schema, so declaring
+`additionalProperties: false` turns that into an error naming the bad argument.
+
+These tests drive the real list_tools and call_tool handlers, because what a
+call is validated against is what list_tools last advertised, not what the
+TOOLS registry holds.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+from mcp import types
+from starlette.requests import Request
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import server  # noqa: E402
+from server import ALL_TOOLS, _is_bridgeable, _strict  # noqa: E402
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class _DictHeaders:
+    def __init__(self, headers):
+        self._headers = {k.lower(): v for k, v in headers.items()}
+
+    def get(self, key, default=None):
+        return self._headers.get(key.lower(), default)
+
+
+def _request(headers):
+    request = Mock(spec=Request)
+    request.headers = _DictHeaders(headers)
+    return request
+
+
+EDGE = {
+    "EDGE_URL": "https://10.0.0.5",
+    "EDGE_API_CLIENT_ID": "id",
+    "EDGE_API_CLIENT_SECRET": "secret",
+}
+LEM = {"EDGE_MANAGER_URL": "https://lem.example.com", "EDGE_API_TOKEN": "token"}
+
+
+def _list_tools(headers):
+    token = server.current_request.set(_request(headers))
+    try:
+        return run(server.handle_list_tools())
+    finally:
+        server.current_request.reset(token)
+
+
+def _call(name, arguments, headers):
+    """Drive the SDK's CallToolRequest handler so input validation runs.
+
+    The tool's own handler is stubbed out: validation happens in the SDK layer
+    before the handler is reached, so stubbing keeps these tests offline
+    instead of waiting on a broker that is not there.
+    """
+    handler = server.mcp.request_handlers[types.CallToolRequest]
+    request = types.CallToolRequest(
+        method="tools/call",
+        params=types.CallToolRequestParams(name=name, arguments=arguments),
+    )
+
+    async def stub(_request, _arguments):
+        return [types.TextContent(type="text", text='{"stubbed": true}')]
+
+    tool = server.TOOL_BY_NAME[name]
+    original = tool["handler"]
+    token = server.current_request.set(_request(headers))
+    try:
+        tool["handler"] = stub
+        return run(handler(request))
+    finally:
+        tool["handler"] = original
+        server.current_request.reset(token)
+
+
+# ── the invariant ────────────────────────────────────────────────────────────
+
+
+def test_every_advertised_tool_rejects_unknown_arguments():
+    tools = _list_tools(EDGE)
+    assert len(tools) == len(ALL_TOOLS)
+    missing = [
+        t.name
+        for t in tools
+        if t.inputSchema.get("additionalProperties") is not False
+    ]
+    assert not missing, f"tools still accepting unknown arguments: {missing}"
+
+
+def test_strict_does_not_mutate_the_registry_schema():
+    original = {"type": "object", "properties": {"a": {"type": "string"}}}
+    strict = _strict(original)
+    assert strict["additionalProperties"] is False
+    assert "additionalProperties" not in original
+
+
+def test_strict_supplies_object_type_when_absent():
+    assert _strict({})["type"] == "object"
+
+
+# ── the behaviour the finding described ──────────────────────────────────────
+
+
+def test_misspelled_argument_is_refused_by_name():
+    """The reviewer's exact repro: count/timeout instead of num_samples."""
+    result = _call(
+        "get_multiple_values_from_topic",
+        {"topic": "devicehub.alias.M1.PartMade", "count": 2, "timeout": 20},
+        EDGE,
+    )
+    payload = result.root
+    assert payload.isError is True
+    text = payload.content[0].text
+    assert "validation error" in text.lower()
+    # The message has to name the offending argument to be actionable.
+    assert "count" in text or "timeout" in text
+
+
+def test_correctly_spelled_arguments_still_validate():
+    """The guard must not reject a well-formed call."""
+    result = _call(
+        "get_multiple_values_from_topic",
+        {"topic": "x", "num_samples": 2},
+        EDGE,
+    )
+    assert result.root.isError is not True
+    assert "stubbed" in result.root.content[0].text
+
+
+# ── the shared tool cache ────────────────────────────────────────────────────
+
+
+def test_bridge_args_are_advertised_without_lem_credentials():
+    """Advertised unconditionally, so a shared cache cannot strip them.
+
+    The SDK keeps one process-wide tool cache that every list_tools call
+    clears and refreshes, and call_tool validates against it. If the bridge
+    arguments were only advertised to LEM-configured clients, a non-LEM
+    client's listing would make a LEM client's bridged call fail validation.
+    """
+    for headers in (EDGE, LEM):
+        by_name = {t.name: t for t in _list_tools(headers)}
+        props = by_name["get_devicehub_devices"].inputSchema["properties"]
+        assert "project_id" in props
+        assert "lem_device_id" in props
+
+
+def test_bridged_call_survives_a_non_lem_client_listing_first():
+    """The regression the unconditional advertisement exists to prevent."""
+    _list_tools(EDGE)  # non-LEM client refreshes the shared cache
+    result = _call(
+        "get_devicehub_devices",
+        {"project_id": "p1", "lem_device_id": "d1"},
+        LEM,
+    )
+    text = result.root.content[0].text
+    assert "additional properties" not in text.lower()
+    assert "validation error" not in text.lower()
+
+
+def test_deprecated_device_id_still_passes_validation():
+    """The alias is declared, so strict validation does not pre-empt it."""
+    _list_tools(EDGE)
+    result = _call(
+        "get_devicehub_devices", {"project_id": "p1", "device_id": "d1"}, LEM
+    )
+    text = result.root.content[0].text
+    assert "validation error" not in text.lower()
+
+
+def test_non_bridgeable_tools_do_not_advertise_bridge_args():
+    by_name = {t.name: t for t in _list_tools(LEM)}
+    lem_tool = next(t for t in ALL_TOOLS if not _is_bridgeable(t))
+    props = by_name[lem_tool["name"]].inputSchema.get("properties", {})
+    assert "lem_device_id" not in props

--- a/uv.lock
+++ b/uv.lock
@@ -627,7 +627,7 @@ wheels = [
 
 [[package]]
 name = "litmus-mcp-server"
-version = "1.3.0"
+version = "1.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Three separate pieces of work, kept in one PR because the version bump has to sit on top of the other two. Reviewable commit by commit.

## Tool schemas reject arguments they do not declare

A misspelled argument was accepted silently and the tool ran with its defaults. The evaluation called `get_multiple_values_from_topic` with `count` and `timeout`; it collected 10 samples over 30s while the caller believed it had asked for 2 over 20, and nothing in the response contradicted that. 36 of the 62 tools accept optional arguments, so this was reachable across most of the surface. It matters most where a default changes the data rather than the page: asking for 7 days of history, mistyping the range argument and silently receiving 1 hour reads as an answer to the question asked.

The SDK validates input against the advertised schema, so `additionalProperties: false` turns that into:

```
Input validation error: Additional properties are not allowed ('count', 'timeout' were unexpected)
```

Applied centrally in `handle_list_tools` rather than written into each of the 62 tool dicts, so it cannot be forgotten on a new tool and no registry schema is mutated in place.

Two couplings this forced, both worth reviewing:

- **The LEM bridge arguments are now advertised unconditionally**, not only to LEM-configured clients. The SDK keeps one process-wide tool cache that every `list_tools` call clears and refreshes, and `call_tool` validates against it, so on a server with more than one client the last listing decides what everybody is validated against. Advertising conditionally would let a non-LEM client's listing make a LEM client's next bridged call fail as unexpected. The arguments are inert without LEM credentials, so this costs nothing and removes the race. There is a test that lists as a non-LEM client and then makes a bridged call.
- **The deprecated `device_id` alias is now declared.** Left undeclared it would be refused by validation before the dispatcher could accept it, breaking exactly the clients the alias exists for. Its description marks it deprecated so a model prefers `lem_device_id`.

Audited before writing any of it: no tool reads an argument absent from its own schema.

## The desktop extension can reach Litmus Unify

#101 added `UNS_*` forwarding to the HTTP transport, but the extension's `HEADER_VARS` did not follow, so `unify.*` was unreachable through the mcpb bundle however the server was configured.

Forwards `UNS_URL`, `UNS_USERNAME` and `UNS_PASSWORD` with three optional `user_config` fields, validated as a group. Unify authenticates separately from Litmus Edge, and filling one field while leaving the others empty otherwise surfaces an SDK error naming internal option names (`unifyURL`, `unifyUsername`) rather than the fields the configuration dialog shows. Now it names the blank fields and offers clearing the group as the alternative.

## 1.4.0, and the CLI fallback pin

The bump automation only rewrites the Dockerfile ARG, so `_FALLBACK_CLI_VERSION` was still `cli-v0.7.0`, two releases behind what the image installs. Now `cli-v0.9.0`.

That pin matters more than it used to: cli-v0.9.0 rejects unknown `--args` keys instead of dropping them. Checked against a live edge that every argument name this repo sends is accepted, and separately confirmed the new strictness works (`unknown argument "bogusKey"`) and that a stale `deviceID` on a `lem.*` path now fails loudly rather than silently sending an empty id.

1.4.0 covers everything since 1.3.0: markdown documentation resources, topic discovery, the `lem_device_id` rename, strict schemas and Unify on both transports. All three declared versions plus `uv.lock` are updated and `scripts/check-versions.sh` passes, including in its tag form. **Not tagged here.**

## Verification

300 Python tests and 18 launcher tests pass, ruff clean, manifest schema validation passes. Verified live over Streamable HTTP: 62 of 62 tools advertise strict schemas, the reviewer's exact repro is refused by name, a bridged call survives a non-LEM client listing first, and the deprecated alias still validates.