### PR TITLE
Read the paginated shape when listing tags for status

### DIFF
--- a/src/tools/devicehub_tools.py
+++ b/src/tools/devicehub_tools.py
@@ -983,14 +983,16 @@ async def _cli_device_tag_statuses(
 ) -> tuple[dict, list]:
     """Return ({tag_id: tag_name}, [{'ID', 'State'}...]) for one device via
     litmus-cli."""
-    cli_tags = (
-        await run_cli_function(
-            request,
-            "le.devicehub.ListDeviceTags",
-            {"deviceID": device_id, "limit": _TAG_LIMIT},
-        )
-        or []
+    page = await run_cli_function(
+        request,
+        "le.devicehub.ListDeviceTags",
+        {"deviceID": device_id, "limit": _TAG_LIMIT},
     )
+    # ListDeviceTags answers with TagPage{Registers, TotalCount, Last}, not a
+    # bare array. Iterating the response itself walks those three keys as
+    # strings, so no tag was ever found and both status tools reported nothing
+    # while still succeeding.
+    cli_tags = page.get("Registers") or [] if isinstance(page, dict) else []
     tag_map = {
         t.get("ID"): t.get("TagName") or t.get("Name")
         for t in cli_tags

--- a/tests/test_cli_backed_tools.py
+++ b/tests/test_cli_backed_tools.py
@@ -212,14 +212,47 @@ def test_attributes_cli_failure_returns_error_response():
 
 # ── tag status ───────────────────────────────────────────────────────────────
 
-DEVICE_TAGS = [
+DEVICE_TAG_ROWS = [
     {"ID": "tag-1", "TagName": "Temperature"},
     {"ID": "tag-2", "TagName": "Pressure"},
 ]
+# ListDeviceTags answers with TagPage{Registers, TotalCount, Last}, not a bare
+# array. This fixture WAS a bare array, which is why both status tools shipped
+# reading zero tags while still reporting success: the tests were validating a
+# shape the CLI never returns. Keep this the real shape.
+DEVICE_TAGS = {"Registers": DEVICE_TAG_ROWS, "TotalCount": 2, "Last": True}
 TAG_STATES = [
     {"ID": "tag-1", "State": "OK"},
     {"ID": "tag-2", "State": "ERROR"},
 ]
+
+
+@patch("tools.devicehub_tools.get_litmus_connection")
+@patch("tools.devicehub_tools._find_device_by_name")
+def test_tag_status_reads_the_paginated_response_shape(mock_find, mock_conn):
+    """Regression: the response is TagPage{Registers, ...}, not a bare array.
+
+    Reading it as an array found no tags and reported an empty status list with
+    success true, i.e. 'no tags are broken' for a device whose tags were never
+    looked at.
+    """
+    mock_conn.return_value = MagicMock()
+    device = MagicMock()
+    device.id = "dev-1"
+    mock_find.return_value = device
+
+    async def fake_cli(request, function, args):
+        if function == "le.devicehub.ListDeviceTags":
+            return DEVICE_TAGS
+        return [{"ID": "tag-1", "State": "Failed"}]
+
+    with patch.object(dh_tools, "run_cli_function", side_effect=fake_cli):
+        data = _parse(
+            _run(get_tag_status(_make_request(), {"device_name": "TestDevice"}))
+        )
+
+    assert data["count"] == 1
+    assert data["statuses"][0]["tag_name"] == "Temperature"
 
 
 @patch("tools.devicehub_tools.get_litmus_connection")
@@ -287,7 +320,11 @@ def test_get_all_tags_status_covers_every_device_and_surfaces_errors():
         if device_id == "dev-3":
             raise CLIFunctionError(function, "unreachable")
         if function == "le.devicehub.ListDeviceTags":
-            return [{"ID": f"{device_id}-t", "TagName": f"{device_id}-tag"}]
+            return {
+                "Registers": [{"ID": f"{device_id}-t", "TagName": f"{device_id}-tag"}],
+                "TotalCount": 1,
+                "Last": True,
+            }
         return [{"ID": f"{device_id}-t", "State": "OK" if device_id == "dev-1" else "ERROR"}]
 
     with patch.object(dh_tools, "run_cli_function", side_effect=fake_cli):


### PR DESCRIPTION
Fixes the one defect from the v1.4.0 re-verification that leaves a tool visibly broken.

## The bug

`get_tag_status` and `get_all_tags_status` returned `{"success": true, "count": 0, "statuses": []}`. A device whose tags were never read is indistinguishable from a device with nothing wrong, so the tools reported a clean bill of health for tags they had not looked at.

`le.devicehub.ListDeviceTags` answers with `TagPage{Registers, TotalCount, Last}`. `_cli_device_tag_statuses` iterated the response directly, which walks those three keys as strings, so `isinstance(t, dict)` was false for every one, the tag map came out empty, and the empty map short-circuited the status lookup before it ran.

Confirmed against a live Edge before and after:

| | before | after |
|---|---|---|
| `get_tag_status` (one device) | `count: 0` | `count: 1`, `RawProbe` / `Failed` |
| `get_all_tags_status` | `count: 0` | `count: 56` across 5 devices |

**Not new in 1.4.0.** Both cli-v0.8.0 and cli-v0.9.0 return the paginated shape, so this has been latent since the CLI moved to the paginated tag API.

## Why CI never caught it

The `DEVICE_TAGS` fixture was a bare array — a shape the CLI does not return. The tests passed against a fiction while the code failed against reality. The fixture now carries the real `TagPage` shape, which is what surfaced the five stale assertions in this diff, and a regression test pins the shape directly.

## Deliberately not included

The re-verification lists two other defects and some observations. Keeping this PR to the one thing that is definitely broken:

- **`tag_name_query` on `get_device_historical_data`** filters measurement names, so it cannot match a tag name where measurements are named per device. Real, but it returns a message rather than silently wrong data, `query_tag_data` covers the use case, and a proper fix would add an Edge-credential requirement to a tool that today needs only InfluxDB. That is a capability decision, not a bug fix.
- **Proxy header stripping** is deployment guidance. nginx drops underscored headers unless `underscores_in_headers` is on; the endpoint under review runs native TLS with no proxy, so nothing is broken today.
- Error-body truncation is upstream in go-sdk and has been handed over.

## Verification

301 tests pass, ruff clean, and both tools confirmed against the live Edge.