### PR TITLE
Bump to 1.4.1 and the CLI fallback pin to cli-v0.9.2

### DIFF
--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "litmus-mcp",
   "display_name": "Litmus MCP",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Connect Claude to Litmus Edge industrial devices through your Litmus MCP Server.",
   "long_description": "Gives Claude access to your Litmus Edge deployment: browse DeviceHub devices and tags, read real-time and historical process data, manage Digital Twins, inspect system health, and reach the full Litmus SDK surface. This extension bridges Claude Desktop to a Litmus MCP Server you run on your own network (see https://github.com/litmusautomation/litmus-mcp-server); your credentials are stored in the operating system keychain and sent only to that server.",
   "author": {

--- a/desktop-extension/package.json
+++ b/desktop-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litmus-mcp-desktop-extension",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Claude Desktop extension bridging stdio to a Litmus MCP Server over streamable HTTP",
   "license": "MIT",
   "private": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litmus-mcp-server"
-version = "1.4.0"
+version = "1.4.1"
 description = "Litmus MCP Server"
 readme = "README.md"
 license = "MIT"

--- a/src/tools/sdk_cli_tools.py
+++ b/src/tools/sdk_cli_tools.py
@@ -108,7 +108,7 @@ def _get_isolated_dir() -> str:
 # same release the Dockerfile pins) instead of hard-failing the CLI-backed
 # tools.
 
-_FALLBACK_CLI_VERSION = "cli-v0.9.0"  # used only when Dockerfile is absent
+_FALLBACK_CLI_VERSION = "cli-v0.9.2"  # used only when Dockerfile is absent
 
 _BOOTSTRAP_BASE_DIR = Path.home() / ".cache" / "litmus-mcp-server" / "bin"
 

--- a/uv.lock
+++ b/uv.lock
@@ -627,7 +627,7 @@ wheels = [
 
 [[package]]
 name = "litmus-mcp-server"
-version = "1.4.0"
+version = "1.4.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Release prep for **v1.4.1**. Needed before the tag: `scripts/check-versions.sh` requires the declared versions to equal the tag, and all three still said 1.4.0 while v1.4.0 was already released, so tagging would have failed the gate.

## Versions

| | before | after |
|---|---|---|
| `pyproject.toml` | 1.4.0 | **1.4.1** |
| `desktop-extension/manifest.json` | 1.4.0 | **1.4.1** |
| `desktop-extension/package.json` | 1.4.0 | **1.4.1** |
| `uv.lock` | 1.4.0 | **1.4.1** (via `uv lock`) |
| `Dockerfile` `LITMUS_CLI_VERSION` | cli-v0.9.2 | unchanged, already bumped in #108 |
| `_FALLBACK_CLI_VERSION` | cli-v0.9.0 | **cli-v0.9.2** |
| litmussdk | 2.7.5 | unchanged, already bumped in #106 |

The fallback pin is the only substantive change. It is read when no Dockerfile is present, e.g. a bare `python src/server.py`, and it had drifted two releases behind because the bump automation only rewrites the Dockerfile ARG. Worth teaching that workflow to rewrite both, or deriving one from the other, since this recurs every release.

## What 1.4.1 contains

- **#107** the tag-status fix. `get_tag_status` and `get_all_tags_status` read the paginated `ListDeviceTags` response (`TagPage{Registers, ...}`) instead of iterating it, so they report real states instead of an empty list with `success: true`. This was the one defect from the v1.4.0 re-verification that left a tool visibly broken.
- **#106** litmussdk 2.7.5.
- **#108** litmus-cli cli-v0.9.2, which carries the folded and bounded error bodies.

## Verification

- `scripts/check-versions.sh v1.4.1` passes, i.e. the gate is satisfied in tag form.
- 301 Python tests and 18 launcher tests pass; ruff clean.
- Server reports version 1.4.1, cli pin and fallback both cli-v0.9.2, litmussdk 2.7.5.
- Pinned CLI checked against a host that answers with HTML: the error is now a single bounded line rather than multi-line markup, so cli-v0.9.2 really does carry the truncation fix.

Tag `v1.4.1` after merge. The tag push builds the Docker image; publishing the GitHub Release is what attaches `litmus-mcp.mcpb`.